### PR TITLE
feat(AUTH-FE-2): client login page

### DIFF
--- a/src/__tests__/views/ClientLoginView.test.ts
+++ b/src/__tests__/views/ClientLoginView.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import ClientLoginView from '../../views/client/ClientLoginView.vue'
+import { useClientAuthStore } from '../../stores/clientAuth'
+
+const mockPush = vi.fn()
+
+vi.mock('vue-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('vue-router')>()
+  return { ...actual, useRouter: () => ({ push: mockPush }) }
+})
+
+vi.mock('../../api/clientAuth', () => ({
+  clientAuthApi: { login: vi.fn() },
+}))
+
+describe('ClientLoginView', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('renders login form with email input, password input, and submit button', () => {
+    const wrapper = mount(ClientLoginView)
+    expect(wrapper.find('input[type="email"]').exists()).toBe(true)
+    expect(wrapper.find('input[type="password"]').exists()).toBe(true)
+    expect(wrapper.find('button[type="submit"]').exists()).toBe(true)
+  })
+
+  it('calls store.login with credentials and redirects to /client/dashboard on success', async () => {
+    const store = useClientAuthStore()
+    const loginSpy = vi.spyOn(store, 'login').mockResolvedValueOnce(undefined)
+
+    const wrapper = mount(ClientLoginView)
+    await wrapper.find('input[type="email"]').setValue('ana@gmail.com')
+    await wrapper.find('input[type="password"]').setValue('password123')
+    await wrapper.find('form').trigger('submit')
+    await flushPromises()
+
+    expect(loginSpy).toHaveBeenCalledWith('ana@gmail.com', 'password123')
+    expect(mockPush).toHaveBeenCalledWith('/client/dashboard')
+  })
+
+  it('shows error message when login fails', async () => {
+    const store = useClientAuthStore()
+    vi.spyOn(store, 'login').mockRejectedValueOnce({
+      response: { data: { message: 'Invalid credentials' } },
+    })
+
+    const wrapper = mount(ClientLoginView)
+    await wrapper.find('input[type="email"]').setValue('bad@gmail.com')
+    await wrapper.find('input[type="password"]').setValue('wrongpass')
+    await wrapper.find('form').trigger('submit')
+    await flushPromises()
+
+    expect(wrapper.find('.global-error').exists()).toBe(true)
+    expect(wrapper.find('.global-error').text()).toContain('Invalid credentials')
+  })
+})

--- a/src/views/client/ClientLoginView.vue
+++ b/src/views/client/ClientLoginView.vue
@@ -1,11 +1,57 @@
 <script setup lang="ts">
+import { ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { useClientAuthStore } from '../../stores/clientAuth'
+
+const router = useRouter()
+const clientAuth = useClientAuthStore()
+
+const email = ref('')
+const password = ref('')
+const error = ref('')
+const loading = ref(false)
+
+async function handleLogin() {
+  if (!email.value || !password.value) {
+    error.value = 'Please enter email and password.'
+    return
+  }
+  loading.value = true
+  error.value = ''
+  try {
+    await clientAuth.login(email.value, password.value)
+    router.push('/client/dashboard')
+  } catch (e: any) {
+    error.value = e.response?.data?.message || 'Invalid credentials.'
+  } finally {
+    loading.value = false
+  }
+}
 </script>
 
 <template>
   <div class="login-page">
     <div class="login-card">
-      <h1>Client Login</h1>
-      <p>Coming in AUTH-FE-2</p>
+      <h1>EXBanka</h1>
+      <h2>Client Portal</h2>
+
+      <form @submit.prevent="handleLogin">
+        <div class="form-group">
+          <label>Email</label>
+          <input v-model="email" type="email" placeholder="your@email.com" required />
+        </div>
+
+        <div class="form-group">
+          <label>Password</label>
+          <input v-model="password" type="password" placeholder="Your password" required />
+        </div>
+
+        <p v-if="error" class="global-error">{{ error }}</p>
+
+        <button type="submit" class="btn-primary" :disabled="loading" style="width:100%;padding:10px">
+          {{ loading ? 'Signing in...' : 'Sign In' }}
+        </button>
+      </form>
     </div>
   </div>
 </template>


### PR DESCRIPTION
## Summary

- Replace stub `ClientLoginView` with full email/password form
- Calls `clientAuth.login()` on submit, redirects to `/client/dashboard` on success
- Displays API error message in `.global-error` on failure
- Reuses existing login styling (login-page, login-card, form-group, btn-primary)
- 3 component tests: form renders, login+redirect on success, error on failure

Fixes #10
