### PR TITLE
feat(CLIENT-FE-3): client management portal — list + filters + edit dialog - Fixes #14

### DIFF
--- a/src/__tests__/stores/client.test.ts
+++ b/src/__tests__/stores/client.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useClientStore } from '../../stores/client'
+import { clientManagementApi } from '../../api/clientManagement'
+
+vi.mock('../../api/clientManagement', () => ({
+  clientManagementApi: {
+    list: vi.fn(),
+    get: vi.fn(),
+    update: vi.fn(),
+  },
+}))
+
+const mockClients = [
+  { id: '1', ime: 'Ana', prezime: 'Jović', email: 'ana@gmail.com', brojTelefona: '0611234567', adresa: 'Ulica 1', aktivan: true },
+  { id: '2', ime: 'Marko', prezime: 'Petrović', email: 'marko@gmail.com', brojTelefona: '', adresa: '', aktivan: false },
+]
+
+describe('useClientStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('fetchClients sets clients and total on success', async () => {
+    vi.mocked(clientManagementApi.list).mockResolvedValueOnce({
+      data: { clients: mockClients, total: '2' },
+    })
+
+    const store = useClientStore()
+    await store.fetchClients()
+
+    expect(store.clients).toHaveLength(2)
+    expect(store.total).toBe(2)
+    expect(store.loading).toBe(false)
+    expect(store.error).toBe('')
+  })
+
+  it('fetchClients sets error on API failure', async () => {
+    vi.mocked(clientManagementApi.list).mockRejectedValueOnce({
+      response: { data: { message: 'Unauthorized' } },
+    })
+
+    const store = useClientStore()
+    await store.fetchClients()
+
+    expect(store.clients).toHaveLength(0)
+    expect(store.error).toBe('Unauthorized')
+    expect(store.loading).toBe(false)
+  })
+
+  it('fetchClients passes filter params to API', async () => {
+    vi.mocked(clientManagementApi.list).mockResolvedValueOnce({
+      data: { clients: [], total: '0' },
+    })
+
+    const store = useClientStore()
+    store.setFilters({ emailFilter: 'ana@gmail.com', nameFilter: 'Ana' })
+    await store.fetchClients()
+
+    expect(clientManagementApi.list).toHaveBeenCalledWith(
+      expect.objectContaining({ emailFilter: 'ana@gmail.com', nameFilter: 'Ana' })
+    )
+  })
+
+  it('getClient returns client detail', async () => {
+    const detail = { id: '1', ime: 'Ana', prezime: 'Jović', datumRodjenja: '1990-01-01', pol: 'F', email: 'ana@gmail.com', brojTelefona: '061', adresa: 'Ulica 1', aktivan: true }
+    vi.mocked(clientManagementApi.get).mockResolvedValueOnce({ data: { client: detail } })
+
+    const store = useClientStore()
+    const result = await store.getClient('1')
+
+    expect(result.email).toBe('ana@gmail.com')
+  })
+
+  it('updateClient calls API and refreshes list', async () => {
+    vi.mocked(clientManagementApi.update).mockResolvedValueOnce({})
+    vi.mocked(clientManagementApi.list).mockResolvedValueOnce({
+      data: { clients: mockClients, total: '2' },
+    })
+
+    const store = useClientStore()
+    await store.updateClient('1', {
+      ime: 'Ana', prezime: 'Jović', datumRodjenja: 631152000,
+      pol: 'F', email: 'ana@gmail.com', brojTelefona: '061', adresa: 'Ulica 1',
+    })
+
+    expect(clientManagementApi.update).toHaveBeenCalledWith('1', expect.any(Object))
+    expect(clientManagementApi.list).toHaveBeenCalled()
+  })
+
+  it('setFilters resets page to 1', () => {
+    const store = useClientStore()
+    store.page = 3
+    store.setFilters({ emailFilter: 'test@test.com' })
+
+    expect(store.page).toBe(1)
+    expect(store.filters.emailFilter).toBe('test@test.com')
+  })
+
+  it('clearFilters resets filters and page', () => {
+    const store = useClientStore()
+    store.setFilters({ emailFilter: 'x@x.com', nameFilter: 'Test' })
+    store.page = 5
+    store.clearFilters()
+
+    expect(store.filters.emailFilter).toBe('')
+    expect(store.filters.nameFilter).toBe('')
+    expect(store.page).toBe(1)
+  })
+})

--- a/src/__tests__/views/ClientManagementView.test.ts
+++ b/src/__tests__/views/ClientManagementView.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import ClientManagementView from '../../views/ClientManagementView.vue'
+import { useClientStore } from '../../stores/client'
+
+vi.mock('../../api/clientManagement', () => ({
+  clientManagementApi: {
+    list: vi.fn(),
+    get: vi.fn(),
+    update: vi.fn(),
+  },
+}))
+
+import { clientManagementApi } from '../../api/clientManagement'
+
+const mockClients = [
+  { id: '1', ime: 'Ana', prezime: 'Jović', email: 'ana@gmail.com', brojTelefona: '061', adresa: 'Ulica 1', aktivan: true },
+  { id: '2', ime: 'Marko', prezime: 'Petrović', email: 'marko@gmail.com', brojTelefona: '', adresa: '', aktivan: false },
+]
+
+describe('ClientManagementView', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+    vi.mocked(clientManagementApi.list).mockResolvedValue({
+      data: { clients: mockClients, total: '2' },
+    })
+  })
+
+  it('renders client table with column headers', async () => {
+    const wrapper = mount(ClientManagementView)
+    await flushPromises()
+
+    expect(wrapper.find('table').exists()).toBe(true)
+    expect(wrapper.text()).toContain('Name')
+    expect(wrapper.text()).toContain('Email')
+    expect(wrapper.text()).toContain('Status')
+  })
+
+  it('renders client rows after fetch', async () => {
+    const wrapper = mount(ClientManagementView)
+    await flushPromises()
+
+    const rows = wrapper.findAll('tbody tr')
+    expect(rows).toHaveLength(2)
+    expect(wrapper.text()).toContain('Ana Jović')
+    expect(wrapper.text()).toContain('Marko Petrović')
+  })
+
+  it('renders filter inputs for email and name', async () => {
+    const wrapper = mount(ClientManagementView)
+    await flushPromises()
+
+    const inputs = wrapper.findAll('input')
+    expect(inputs.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('calls fetchClients on mount', async () => {
+    mount(ClientManagementView)
+    await flushPromises()
+
+    expect(clientManagementApi.list).toHaveBeenCalledTimes(1)
+  })
+
+  it('opens edit dialog when Edit button clicked', async () => {
+    const detail = { id: '1', ime: 'Ana', prezime: 'Jović', datumRodjenja: '1990-01-01', pol: 'F', email: 'ana@gmail.com', brojTelefona: '061', adresa: 'Ulica 1', aktivan: true }
+    vi.mocked(clientManagementApi.get).mockResolvedValueOnce({ data: { client: detail } })
+
+    const wrapper = mount(ClientManagementView)
+    await flushPromises()
+
+    const editBtn = wrapper.findAll('button').find(b => b.text() === 'Edit')
+    await editBtn!.trigger('click')
+    await flushPromises()
+
+    expect(wrapper.find('.modal-overlay').exists()).toBe(true)
+    expect(wrapper.text()).toContain('Edit Client')
+  })
+
+  it('closes edit dialog when Cancel clicked', async () => {
+    const detail = { id: '1', ime: 'Ana', prezime: 'Jović', datumRodjenja: '1990-01-01', pol: 'F', email: 'ana@gmail.com', brojTelefona: '061', adresa: 'Ulica 1', aktivan: true }
+    vi.mocked(clientManagementApi.get).mockResolvedValueOnce({ data: { client: detail } })
+
+    const wrapper = mount(ClientManagementView)
+    await flushPromises()
+
+    await wrapper.findAll('button').find(b => b.text() === 'Edit')!.trigger('click')
+    await flushPromises()
+    expect(wrapper.find('.modal-overlay').exists()).toBe(true)
+
+    await wrapper.find('.modal-close').trigger('click')
+    expect(wrapper.find('.modal-overlay').exists()).toBe(false)
+  })
+
+  it('shows Active/Inactive status badges', async () => {
+    const wrapper = mount(ClientManagementView)
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Active')
+    expect(wrapper.text()).toContain('Inactive')
+  })
+})

--- a/src/api/clientManagement.ts
+++ b/src/api/clientManagement.ts
@@ -1,0 +1,46 @@
+import api from './client'
+
+export interface ClientListItem {
+  id: string
+  ime: string
+  prezime: string
+  email: string
+  brojTelefona: string
+  adresa: string
+  aktivan: boolean
+}
+
+export interface ClientDetail {
+  id: string
+  ime: string
+  prezime: string
+  datumRodjenja: string
+  pol: string
+  email: string
+  brojTelefona: string
+  adresa: string
+  aktivan: boolean
+}
+
+export interface UpdateClientPayload {
+  ime: string
+  prezime: string
+  datumRodjenja: number
+  pol: string
+  email: string
+  brojTelefona: string
+  adresa: string
+}
+
+export const clientManagementApi = {
+  list: (params: {
+    emailFilter?: string
+    nameFilter?: string
+    page?: number
+    pageSize?: number
+  }) => api.get('/clients', { params }),
+
+  get: (id: string) => api.get(`/clients/${id}`),
+
+  update: (id: string, data: UpdateClientPayload) => api.put(`/clients/${id}`, data),
+}

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -31,6 +31,10 @@ const router = createRouter({
       path: '/employees',
       component: () => import('../views/EmployeeListView.vue'),
     },
+    {
+      path: '/clients',
+      component: () => import('../views/ClientManagementView.vue'),
+    },
     ...clientRoutes,
   ],
 })

--- a/src/stores/client.ts
+++ b/src/stores/client.ts
@@ -1,0 +1,77 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import {
+  clientManagementApi,
+  type ClientListItem,
+  type ClientDetail,
+  type UpdateClientPayload,
+} from '../api/clientManagement'
+
+interface ClientFilters {
+  emailFilter: string
+  nameFilter: string
+}
+
+export const useClientStore = defineStore('client', () => {
+  const clients = ref<ClientListItem[]>([])
+  const total = ref(0)
+  const page = ref(1)
+  const pageSize = 20
+  const filters = ref<ClientFilters>({ emailFilter: '', nameFilter: '' })
+  const loading = ref(false)
+  const error = ref('')
+
+  async function fetchClients() {
+    loading.value = true
+    error.value = ''
+    try {
+      const res = await clientManagementApi.list({
+        emailFilter: filters.value.emailFilter || undefined,
+        nameFilter: filters.value.nameFilter || undefined,
+        page: page.value,
+        pageSize,
+      })
+      clients.value = res.data.clients ?? []
+      total.value = Number(res.data.total ?? 0)
+    } catch (e: any) {
+      error.value = e.response?.data?.message || 'Failed to load clients.'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function getClient(id: string): Promise<ClientDetail> {
+    const res = await clientManagementApi.get(id)
+    return res.data.client
+  }
+
+  async function updateClient(id: string, data: UpdateClientPayload) {
+    await clientManagementApi.update(id, data)
+    await fetchClients()
+  }
+
+  function setFilters(newFilters: Partial<ClientFilters>) {
+    Object.assign(filters.value, newFilters)
+    page.value = 1
+  }
+
+  function clearFilters() {
+    filters.value = { emailFilter: '', nameFilter: '' }
+    page.value = 1
+  }
+
+  return {
+    clients,
+    total,
+    page,
+    pageSize,
+    filters,
+    loading,
+    error,
+    fetchClients,
+    getClient,
+    updateClient,
+    setFilters,
+    clearFilters,
+  }
+})

--- a/src/views/ClientManagementView.vue
+++ b/src/views/ClientManagementView.vue
@@ -1,0 +1,212 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { clientManagementApi, type ClientDetail, type UpdateClientPayload } from '../api/clientManagement'
+import { useClientStore } from '../stores/client'
+
+const store = useClientStore()
+
+const editingClient = ref<ClientDetail | null>(null)
+const editForm = ref<UpdateClientPayload & { datumRodjenjaStr: string }>({
+  ime: '', prezime: '', datumRodjenja: 0, datumRodjenjaStr: '',
+  pol: 'M', email: '', brojTelefona: '', adresa: '',
+})
+const editError = ref('')
+const editLoading = ref(false)
+
+async function openEdit(clientId: string) {
+  try {
+    const detail = await store.getClient(clientId)
+    editingClient.value = detail
+    editForm.value = {
+      ime: detail.ime,
+      prezime: detail.prezime,
+      datumRodjenja: 0,
+      datumRodjenjaStr: detail.datumRodjenja ? detail.datumRodjenja.substring(0, 10) : '',
+      pol: detail.pol || 'M',
+      email: detail.email,
+      brojTelefona: detail.brojTelefona || '',
+      adresa: detail.adresa || '',
+    }
+    editError.value = ''
+  } catch {
+    store.error = 'Failed to load client details.'
+  }
+}
+
+async function handleSave() {
+  if (!editingClient.value) return
+  editError.value = ''
+  editLoading.value = true
+  try {
+    const payload: UpdateClientPayload = {
+      ime: editForm.value.ime,
+      prezime: editForm.value.prezime,
+      datumRodjenja: editForm.value.datumRodjenjaStr
+        ? Math.floor(new Date(editForm.value.datumRodjenjaStr).getTime() / 1000)
+        : 0,
+      pol: editForm.value.pol,
+      email: editForm.value.email,
+      brojTelefona: editForm.value.brojTelefona,
+      adresa: editForm.value.adresa,
+    }
+    await store.updateClient(editingClient.value.id, payload)
+    editingClient.value = null
+  } catch (e: any) {
+    editError.value = e.response?.data?.message || 'Failed to save changes.'
+  } finally {
+    editLoading.value = false
+  }
+}
+
+function applyFilters() {
+  store.setFilters({
+    emailFilter: store.filters.emailFilter,
+    nameFilter: store.filters.nameFilter,
+  })
+  store.fetchClients()
+}
+
+function clearFilters() {
+  store.clearFilters()
+  store.fetchClients()
+}
+
+const totalPages = () => Math.ceil(store.total / store.pageSize)
+
+onMounted(() => store.fetchClients())
+</script>
+
+<template>
+  <div class="page-content">
+    <div class="page-header">
+      <h1>Clients</h1>
+    </div>
+
+    <!-- Filters -->
+    <div class="filters">
+      <input
+        v-model="store.filters.emailFilter"
+        placeholder="Filter by email"
+        @keyup.enter="applyFilters"
+      />
+      <input
+        v-model="store.filters.nameFilter"
+        placeholder="Filter by name"
+        @keyup.enter="applyFilters"
+      />
+      <button class="btn-primary" @click="applyFilters">Search</button>
+      <button class="btn-secondary" @click="clearFilters">Clear</button>
+    </div>
+
+    <p v-if="store.error" class="global-error" style="margin-bottom:12px">{{ store.error }}</p>
+
+    <!-- Table -->
+    <div class="card" style="padding:0;overflow:hidden">
+      <table>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Email</th>
+            <th>Phone</th>
+            <th>Status</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-if="store.loading">
+            <td colspan="5" style="text-align:center;padding:24px;color:#6b7280">Loading...</td>
+          </tr>
+          <tr v-else-if="store.clients.length === 0">
+            <td colspan="5" style="text-align:center;padding:24px;color:#6b7280">No clients found.</td>
+          </tr>
+          <tr v-for="client in store.clients" :key="client.id">
+            <td>
+              <div style="font-weight:500">{{ client.ime }} {{ client.prezime }}</div>
+            </td>
+            <td>{{ client.email }}</td>
+            <td>{{ client.brojTelefona || '—' }}</td>
+            <td>
+              <span :class="client.aktivan ? 'badge badge-green' : 'badge badge-red'">
+                {{ client.aktivan ? 'Active' : 'Inactive' }}
+              </span>
+            </td>
+            <td>
+              <div class="table-actions">
+                <button class="btn-primary btn-sm" @click="openEdit(client.id)">Edit</button>
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <!-- Pagination -->
+    <div v-if="store.total > store.pageSize" class="pagination">
+      <button class="btn-secondary btn-sm" :disabled="store.page <= 1" @click="store.page--; store.fetchClients()">←</button>
+      <span>Page {{ store.page }} of {{ totalPages() }} ({{ store.total }} total)</span>
+      <button class="btn-secondary btn-sm" :disabled="store.page >= totalPages()" @click="store.page++; store.fetchClients()">→</button>
+    </div>
+  </div>
+
+  <!-- Edit dialog -->
+  <div v-if="editingClient" class="modal-overlay" @click.self="editingClient = null">
+    <div class="modal">
+      <div class="modal-header">
+        <h2>Edit Client</h2>
+        <button class="modal-close" @click="editingClient = null">✕</button>
+      </div>
+
+      <div class="modal-body">
+        <div class="form-row">
+          <div class="form-group">
+            <label>First Name *</label>
+            <input v-model="editForm.ime" required />
+          </div>
+          <div class="form-group">
+            <label>Last Name *</label>
+            <input v-model="editForm.prezime" required />
+          </div>
+        </div>
+
+        <div class="form-row">
+          <div class="form-group">
+            <label>Date of Birth</label>
+            <input v-model="editForm.datumRodjenjaStr" type="date" />
+          </div>
+          <div class="form-group">
+            <label>Gender</label>
+            <select v-model="editForm.pol">
+              <option value="M">Male</option>
+              <option value="F">Female</option>
+            </select>
+          </div>
+        </div>
+
+        <div class="form-row">
+          <div class="form-group">
+            <label>Email *</label>
+            <input v-model="editForm.email" type="email" required />
+          </div>
+          <div class="form-group">
+            <label>Phone</label>
+            <input v-model="editForm.brojTelefona" />
+          </div>
+        </div>
+
+        <div class="form-group">
+          <label>Address</label>
+          <input v-model="editForm.adresa" />
+        </div>
+
+        <p v-if="editError" class="global-error">{{ editError }}</p>
+      </div>
+
+      <div class="modal-footer">
+        <button class="btn-secondary" @click="editingClient = null">Cancel</button>
+        <button class="btn-primary" @click="handleSave" :disabled="editLoading">
+          {{ editLoading ? 'Saving...' : 'Save Changes' }}
+        </button>
+      </div>
+    </div>
+  </div>
+</template>


### PR DESCRIPTION
Implements Issue #31 (CLIENT-FE-3/GH#14):

- `src/api/clientManagement.ts` — list/get/update API calls
- `src/stores/client.ts` — Pinia store with fetchClients, getClient, updateClient, filters, pagination
- `src/views/ClientManagementView.vue` — employee portal: table with name/email/phone/status, email+name filters, pagination, inline edit dialog
- Route `/clients` added to router
- 7 store unit tests + 7 view unit tests (all GREEN)

Fixes #14