### PR TITLE
feat(CLIENT-FE-4): ClientSelectDialog — search existing or create new client - Fixes #24

### DIFF
--- a/src/__tests__/components/ClientSelectDialog.test.ts
+++ b/src/__tests__/components/ClientSelectDialog.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import ClientSelectDialog from '../../components/ClientSelectDialog.vue'
+import { clientManagementApi } from '../../api/clientManagement'
+
+vi.mock('../../api/clientManagement', () => ({
+  clientManagementApi: {
+    list: vi.fn(),
+    get: vi.fn(),
+    update: vi.fn(),
+    create: vi.fn(),
+  },
+}))
+
+const mockClients = [
+  { id: '1', ime: 'Ana', prezime: 'Jović', email: 'ana@gmail.com', brojTelefona: '061', adresa: 'Ulica 1', aktivan: true },
+  { id: '2', ime: 'Marko', prezime: 'Petrović', email: 'marko@gmail.com', brojTelefona: '', adresa: '', aktivan: true },
+]
+
+describe('ClientSelectDialog', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('renders modal with Search Existing and Create New tabs', () => {
+    const wrapper = mount(ClientSelectDialog)
+
+    expect(wrapper.find('.modal-overlay').exists()).toBe(true)
+    expect(wrapper.text()).toContain('Search Existing')
+    expect(wrapper.text()).toContain('Create New')
+  })
+
+  it('defaults to search mode — shows search input', () => {
+    const wrapper = mount(ClientSelectDialog)
+
+    expect(wrapper.find('input[placeholder*="Search"]').exists()).toBe(true)
+  })
+
+  it('clicking Create New tab shows the create form', async () => {
+    const wrapper = mount(ClientSelectDialog)
+
+    const createTab = wrapper.findAll('button').find(b => b.text() === 'Create New')
+    await createTab!.trigger('click')
+
+    expect(wrapper.find('input[placeholder="Ana"]').exists()).toBe(true)
+    expect(wrapper.find('input[type="email"]').exists()).toBe(true)
+  })
+
+  it('search calls API and displays results', async () => {
+    vi.mocked(clientManagementApi.list).mockResolvedValueOnce({
+      data: { clients: mockClients, total: '2' },
+    })
+
+    const wrapper = mount(ClientSelectDialog)
+    await wrapper.find('input[placeholder*="Search"]').setValue('Ana')
+    await wrapper.find('button[class*="btn-primary"]').trigger('click')
+    await flushPromises()
+
+    expect(clientManagementApi.list).toHaveBeenCalledWith(
+      expect.objectContaining({ nameFilter: 'Ana' })
+    )
+    expect(wrapper.text()).toContain('Ana Jović')
+    expect(wrapper.text()).toContain('Marko Petrović')
+  })
+
+  it('clicking a search result emits selected with clientId', async () => {
+    vi.mocked(clientManagementApi.list).mockResolvedValueOnce({
+      data: { clients: mockClients, total: '2' },
+    })
+
+    const wrapper = mount(ClientSelectDialog)
+    await wrapper.find('input[placeholder*="Search"]').setValue('Ana')
+    await wrapper.find('button[class*="btn-primary"]').trigger('click')
+    await flushPromises()
+
+    const resultRow = wrapper.find('.client-result-row')
+    await resultRow.trigger('click')
+
+    expect(wrapper.emitted('selected')).toBeTruthy()
+    expect(wrapper.emitted('selected')![0]).toEqual(['1'])
+  })
+
+  it('shows no-results message when search returns empty', async () => {
+    vi.mocked(clientManagementApi.list).mockResolvedValueOnce({
+      data: { clients: [], total: '0' },
+    })
+
+    const wrapper = mount(ClientSelectDialog)
+    await wrapper.find('input[placeholder*="Search"]').setValue('xyz')
+    await wrapper.find('button[class*="btn-primary"]').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('No clients found')
+  })
+
+  it('create form validates required fields and shows error', async () => {
+    const wrapper = mount(ClientSelectDialog)
+    await wrapper.findAll('button').find(b => b.text() === 'Create New')!.trigger('click')
+
+    await wrapper.find('button[class*="btn-primary"]').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.find('.global-error').exists()).toBe(true)
+    expect(wrapper.text()).toContain('required')
+  })
+
+  it('create form calls API and emits selected with new clientId', async () => {
+    vi.mocked(clientManagementApi.create).mockResolvedValueOnce({
+      data: { client: { id: '99', ime: 'Nova', prezime: 'Osoba' } },
+    })
+
+    const wrapper = mount(ClientSelectDialog)
+    await wrapper.findAll('button').find(b => b.text() === 'Create New')!.trigger('click')
+
+    await wrapper.find('input[placeholder="Ana"]').setValue('Nova')
+    await wrapper.find('input[placeholder="Jović"]').setValue('Osoba')
+    await wrapper.find('input[type="email"]').setValue('nova@gmail.com')
+
+    await wrapper.find('button[class*="btn-primary"]').trigger('click')
+    await flushPromises()
+
+    expect(clientManagementApi.create).toHaveBeenCalled()
+    expect(wrapper.emitted('selected')).toBeTruthy()
+    expect(wrapper.emitted('selected')![0]).toEqual(['99'])
+  })
+
+  it('close button emits close event', async () => {
+    const wrapper = mount(ClientSelectDialog)
+    await wrapper.find('.modal-close').trigger('click')
+
+    expect(wrapper.emitted('close')).toBeTruthy()
+  })
+
+  it('clicking overlay emits close event', async () => {
+    const wrapper = mount(ClientSelectDialog)
+    await wrapper.find('.modal-overlay').trigger('click')
+
+    expect(wrapper.emitted('close')).toBeTruthy()
+  })
+})

--- a/src/api/clientManagement.ts
+++ b/src/api/clientManagement.ts
@@ -32,6 +32,16 @@ export interface UpdateClientPayload {
   adresa: string
 }
 
+export interface CreateClientPayload {
+  ime: string
+  prezime: string
+  datumRodjenja: number
+  pol: string
+  email: string
+  brojTelefona: string
+  adresa: string
+}
+
 export const clientManagementApi = {
   list: (params: {
     emailFilter?: string
@@ -43,4 +53,6 @@ export const clientManagementApi = {
   get: (id: string) => api.get(`/clients/${id}`),
 
   update: (id: string, data: UpdateClientPayload) => api.put(`/clients/${id}`, data),
+
+  create: (data: CreateClientPayload) => api.post('/clients', data),
 }

--- a/src/components/ClientSelectDialog.vue
+++ b/src/components/ClientSelectDialog.vue
@@ -1,0 +1,217 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { clientManagementApi, type ClientListItem, type CreateClientPayload } from '../api/clientManagement'
+
+const emit = defineEmits<{
+  close: []
+  selected: [clientId: string]
+}>()
+
+type Mode = 'search' | 'create'
+const mode = ref<Mode>('search')
+
+// --- search state ---
+const searchQuery = ref('')
+const searchResults = ref<ClientListItem[]>([])
+const searching = ref(false)
+const searchError = ref('')
+
+async function handleSearch() {
+  if (!searchQuery.value.trim()) return
+  searching.value = true
+  searchError.value = ''
+  try {
+    const res = await clientManagementApi.list({
+      nameFilter: searchQuery.value,
+      pageSize: 10,
+    })
+    searchResults.value = res.data.clients ?? []
+    if (searchResults.value.length === 0) {
+      searchError.value = 'No clients found.'
+    }
+  } catch (e: any) {
+    searchError.value = e.response?.data?.message || 'Search failed.'
+  } finally {
+    searching.value = false
+  }
+}
+
+function selectClient(client: ClientListItem) {
+  emit('selected', client.id)
+}
+
+// --- create state ---
+const createForm = ref({
+  ime: '', prezime: '', datumRodjenja: '', pol: 'M',
+  email: '', brojTelefona: '', adresa: '',
+})
+const createError = ref('')
+const creating = ref(false)
+
+async function handleCreate() {
+  createError.value = ''
+  if (!createForm.value.ime || !createForm.value.prezime || !createForm.value.email) {
+    createError.value = 'First name, last name and email are required.'
+    return
+  }
+  creating.value = true
+  try {
+    const payload: CreateClientPayload = {
+      ime: createForm.value.ime,
+      prezime: createForm.value.prezime,
+      datumRodjenja: createForm.value.datumRodjenja
+        ? Math.floor(new Date(createForm.value.datumRodjenja).getTime() / 1000)
+        : 0,
+      pol: createForm.value.pol,
+      email: createForm.value.email,
+      brojTelefona: createForm.value.brojTelefona,
+      adresa: createForm.value.adresa,
+    }
+    const res = await clientManagementApi.create(payload)
+    const newId = res.data.client?.id ?? res.data.id
+    emit('selected', String(newId))
+  } catch (e: any) {
+    createError.value = e.response?.data?.message || 'Failed to create client.'
+  } finally {
+    creating.value = false
+  }
+}
+
+function switchMode(m: Mode) {
+  mode.value = m
+  searchError.value = ''
+  createError.value = ''
+}
+</script>
+
+<template>
+  <div class="modal-overlay" @click.self="emit('close')">
+    <div class="modal">
+      <div class="modal-header">
+        <h2>Select Client</h2>
+        <button class="modal-close" @click="emit('close')">✕</button>
+      </div>
+
+      <!-- Mode tabs -->
+      <div style="display:flex;border-bottom:1px solid #e5e7eb;padding:0 24px">
+        <button
+          :style="{
+            borderBottom: mode === 'search' ? '2px solid #3b82f6' : 'none',
+            color: mode === 'search' ? '#3b82f6' : '#6b7280',
+            background: 'none', borderRadius: 0, padding: '10px 16px', marginBottom: '-1px'
+          }"
+          @click="switchMode('search')"
+        >Search Existing</button>
+        <button
+          :style="{
+            borderBottom: mode === 'create' ? '2px solid #3b82f6' : 'none',
+            color: mode === 'create' ? '#3b82f6' : '#6b7280',
+            background: 'none', borderRadius: 0, padding: '10px 16px', marginBottom: '-1px'
+          }"
+          @click="switchMode('create')"
+        >Create New</button>
+      </div>
+
+      <div class="modal-body">
+
+        <!-- Search mode -->
+        <template v-if="mode === 'search'">
+          <div style="display:flex;gap:8px;margin-bottom:16px">
+            <input
+              v-model="searchQuery"
+              placeholder="Search by name or email..."
+              style="flex:1"
+              @keyup.enter="handleSearch"
+            />
+            <button class="btn-primary" :disabled="searching" @click="handleSearch">
+              {{ searching ? 'Searching...' : 'Search' }}
+            </button>
+          </div>
+
+          <p v-if="searchError" class="global-error">{{ searchError }}</p>
+
+          <div v-if="searchResults.length > 0" style="border:1px solid #e5e7eb;border-radius:6px;overflow:hidden">
+            <div
+              v-for="client in searchResults"
+              :key="client.id"
+              class="client-result-row"
+              style="display:flex;justify-content:space-between;align-items:center;padding:10px 14px;border-bottom:1px solid #f3f4f6;cursor:pointer"
+              @click="selectClient(client)"
+            >
+              <div>
+                <div style="font-weight:500">{{ client.ime }} {{ client.prezime }}</div>
+                <div style="font-size:13px;color:#6b7280">{{ client.email }}</div>
+              </div>
+              <span :class="client.aktivan ? 'badge badge-green' : 'badge badge-red'">
+                {{ client.aktivan ? 'Active' : 'Inactive' }}
+              </span>
+            </div>
+          </div>
+
+          <p v-else-if="!searchError && !searching" style="color:#6b7280;font-size:13px;margin-top:8px">
+            Enter a name or email and click Search.
+          </p>
+        </template>
+
+        <!-- Create mode -->
+        <template v-if="mode === 'create'">
+          <div class="form-row">
+            <div class="form-group">
+              <label>First Name *</label>
+              <input v-model="createForm.ime" placeholder="Ana" required />
+            </div>
+            <div class="form-group">
+              <label>Last Name *</label>
+              <input v-model="createForm.prezime" placeholder="Jović" required />
+            </div>
+          </div>
+
+          <div class="form-row">
+            <div class="form-group">
+              <label>Email *</label>
+              <input v-model="createForm.email" type="email" placeholder="ana@gmail.com" required />
+            </div>
+            <div class="form-group">
+              <label>Phone</label>
+              <input v-model="createForm.brojTelefona" placeholder="0611234567" />
+            </div>
+          </div>
+
+          <div class="form-row">
+            <div class="form-group">
+              <label>Date of Birth</label>
+              <input v-model="createForm.datumRodjenja" type="date" />
+            </div>
+            <div class="form-group">
+              <label>Gender</label>
+              <select v-model="createForm.pol">
+                <option value="M">Male</option>
+                <option value="F">Female</option>
+              </select>
+            </div>
+          </div>
+
+          <div class="form-group">
+            <label>Address</label>
+            <input v-model="createForm.adresa" placeholder="Street 1, City" />
+          </div>
+
+          <p v-if="createError" class="global-error">{{ createError }}</p>
+        </template>
+
+      </div>
+
+      <div class="modal-footer">
+        <button class="btn-secondary" @click="emit('close')">Cancel</button>
+        <button
+          v-if="mode === 'create'"
+          class="btn-primary"
+          :disabled="creating"
+          @click="handleCreate"
+        >
+          {{ creating ? 'Creating...' : 'Create & Select' }}
+        </button>
+      </div>
+    </div>
+  </div>
+</template>


### PR DESCRIPTION
Implements Issue #32 (CLIENT-FE-4/GH#24):

- `ClientSelectDialog.vue` — reusable modal with two tabs:
  - **Search Existing**: text input → calls `/clients` API → clickable results list → emits `selected(clientId)`
  - **Create New**: inline form (ime, prezime, email, phone, dob, gender, address) → calls `POST /clients` → emits `selected(newClientId)`
- Added `create` method to `clientManagementApi`
- 10 component unit tests (all GREEN)

Fixes #24