### PR TITLE
feat(ACCOUNT-FE-7): create account form — client select, currency, tip/vrsta, firma - Fixes #11

### DIFF
--- a/src/__tests__/stores/account.test.ts
+++ b/src/__tests__/stores/account.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useAccountStore } from '../../stores/account'
+import { accountApi } from '../../api/account'
+
+vi.mock('../../api/account', () => ({
+  accountApi: {
+    create: vi.fn(),
+    get: vi.fn(),
+    listByClient: vi.fn(),
+    listAll: vi.fn(),
+    updateName: vi.fn(),
+    updateLimits: vi.fn(),
+  },
+  CURRENCIES: [
+    { id: 1, kod: 'RSD', naziv: 'Serbian Dinar' },
+    { id: 2, kod: 'EUR', naziv: 'Euro' },
+  ],
+}))
+
+const mockAccount = {
+  id: '42', brojRacuna: '123456789012345678', clientId: '1',
+  firmaId: '0', currencyId: '2', currencyKod: 'EUR',
+  tip: 'tekuci', vrsta: 'licni', stanje: 0, raspolozivoStanje: 0,
+  dnevniLimit: 100000, mesecniLimit: 1000000, naziv: '', status: 'aktivan',
+}
+
+describe('useAccountStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('createAccount calls API and returns account on success', async () => {
+    vi.mocked(accountApi.create).mockResolvedValueOnce({ data: { account: mockAccount } })
+
+    const store = useAccountStore()
+    const result = await store.createAccount({
+      clientId: 1, currencyId: 2, tip: 'tekuci', vrsta: 'licni',
+    })
+
+    expect(accountApi.create).toHaveBeenCalledWith(
+      expect.objectContaining({ clientId: 1, currencyId: 2, tip: 'tekuci', vrsta: 'licni' })
+    )
+    expect(result.id).toBe('42')
+    expect(store.lastCreated?.id).toBe('42')
+  })
+
+  it('createAccount sets loading true during request', async () => {
+    let resolvePromise!: (v: any) => void
+    vi.mocked(accountApi.create).mockReturnValueOnce(
+      new Promise(resolve => { resolvePromise = resolve })
+    )
+
+    const store = useAccountStore()
+    const promise = store.createAccount({ clientId: 1, currencyId: 2, tip: 'tekuci', vrsta: 'licni' })
+    expect(store.loading).toBe(true)
+
+    resolvePromise({ data: { account: mockAccount } })
+    await promise
+    expect(store.loading).toBe(false)
+  })
+
+  it('createAccount sets error and rethrows on API failure', async () => {
+    vi.mocked(accountApi.create).mockRejectedValueOnce({
+      response: { data: { message: 'devizni account cannot use RSD' } },
+    })
+
+    const store = useAccountStore()
+    await expect(store.createAccount({ clientId: 1, currencyId: 1, tip: 'devizni', vrsta: 'licni' }))
+      .rejects.toBeDefined()
+
+    expect(store.error).toBe('devizni account cannot use RSD')
+    expect(store.loading).toBe(false)
+  })
+
+  it('clearError resets error state', () => {
+    const store = useAccountStore()
+    store.error = 'some error'
+    store.clearError()
+    expect(store.error).toBe('')
+  })
+})

--- a/src/__tests__/views/CreateAccountView.test.ts
+++ b/src/__tests__/views/CreateAccountView.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import CreateAccountView from '../../views/CreateAccountView.vue'
+import { useAccountStore } from '../../stores/account'
+
+const mockPush = vi.fn()
+
+vi.mock('vue-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('vue-router')>()
+  return { ...actual, useRouter: () => ({ push: mockPush }) }
+})
+
+vi.mock('../../api/account', () => ({
+  accountApi: { create: vi.fn() },
+  CURRENCIES: [
+    { id: 1, kod: 'RSD', naziv: 'Serbian Dinar' },
+    { id: 2, kod: 'EUR', naziv: 'Euro' },
+    { id: 3, kod: 'USD', naziv: 'US Dollar' },
+  ],
+}))
+
+vi.mock('../../components/ClientSelectDialog.vue', () => ({
+  default: { template: '<div class="mock-client-dialog" />' },
+}))
+
+vi.mock('../../api/clientManagement', () => ({
+  clientManagementApi: { list: vi.fn(), get: vi.fn(), update: vi.fn(), create: vi.fn() },
+}))
+
+describe('CreateAccountView', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('renders the form with all required sections', () => {
+    const wrapper = mount(CreateAccountView)
+
+    expect(wrapper.text()).toContain('Create Account')
+    expect(wrapper.text()).toContain('Currency')
+    expect(wrapper.text()).toContain('Account Type')
+    expect(wrapper.text()).toContain('Account Kind')
+  })
+
+  it('renders currency dropdown with options', () => {
+    const wrapper = mount(CreateAccountView)
+    const select = wrapper.find('select')
+    expect(select.exists()).toBe(true)
+    const options = select.findAll('option')
+    expect(options.length).toBeGreaterThanOrEqual(3)
+  })
+
+  it('renders tekuci and devizni radio buttons', () => {
+    const wrapper = mount(CreateAccountView)
+    const radios = wrapper.findAll('input[type="radio"]')
+    const values = radios.map(r => r.element.value)
+    expect(values).toContain('tekuci')
+    expect(values).toContain('devizni')
+  })
+
+  it('renders licni and poslovni radio buttons', () => {
+    const wrapper = mount(CreateAccountView)
+    const radios = wrapper.findAll('input[type="radio"]')
+    const values = radios.map(r => r.element.value)
+    expect(values).toContain('licni')
+    expect(values).toContain('poslovni')
+  })
+
+  it('shows firma ID input when poslovni is selected', async () => {
+    const wrapper = mount(CreateAccountView)
+
+    const poslovniRadio = wrapper.findAll('input[type="radio"]').find(r => r.element.value === 'poslovni')
+    await poslovniRadio!.setValue('poslovni')
+    await poslovniRadio!.trigger('change')
+
+    expect(wrapper.text()).toContain('Firma ID')
+    expect(wrapper.find('input[type="number"]').exists()).toBe(true)
+  })
+
+  it('does not show firma ID input when licni is selected', () => {
+    const wrapper = mount(CreateAccountView)
+    expect(wrapper.find('input[type="number"]').exists()).toBe(false)
+  })
+
+  it('renders disabled card checkbox (Sprint 2 guardrail)', () => {
+    const wrapper = mount(CreateAccountView)
+    const cardCheckbox = wrapper.find('#card-checkbox')
+    expect(cardCheckbox.exists()).toBe(true)
+    expect((cardCheckbox.element as HTMLInputElement).disabled).toBe(true)
+  })
+
+  it('shows error when submitting without a client selected', async () => {
+    const wrapper = mount(CreateAccountView)
+    const store = useAccountStore()
+
+    await wrapper.find('button[class*="btn-primary"]').trigger('click')
+    await flushPromises()
+
+    expect(store.error).toContain('client')
+  })
+
+  it('opens ClientSelectDialog when Select Client button clicked', async () => {
+    const wrapper = mount(CreateAccountView)
+
+    await wrapper.find('button[class*="btn-secondary"]').trigger('click')
+
+    expect(wrapper.find('.mock-client-dialog').exists()).toBe(true)
+  })
+
+  it('calls store.createAccount and redirects on success', async () => {
+    const store = useAccountStore()
+    const createSpy = vi.spyOn(store, 'createAccount').mockResolvedValueOnce({
+      id: '99', brojRacuna: '111111111111111111', clientId: '1', firmaId: '0',
+      currencyId: '2', currencyKod: 'EUR', tip: 'tekuci', vrsta: 'licni',
+      stanje: 0, raspolozivoStanje: 0, dnevniLimit: 100000, mesecniLimit: 1000000,
+      naziv: '', status: 'aktivan',
+    })
+
+    const wrapper = mount(CreateAccountView)
+
+    // Simulate client selection via component internals
+    wrapper.vm.selectedClientId = '1'
+    wrapper.vm.selectedClientLabel = 'Ana Jović'
+    await wrapper.vm.$nextTick()
+
+    await wrapper.find('button[class*="btn-primary"]').trigger('click')
+    await flushPromises()
+
+    expect(createSpy).toHaveBeenCalled()
+    expect(mockPush).toHaveBeenCalledWith('/accounts')
+  })
+})

--- a/src/api/account.ts
+++ b/src/api/account.ts
@@ -1,0 +1,79 @@
+import api from './client'
+
+// Static currency list matching seed order (INFRA-BE-2)
+export const CURRENCIES = [
+  { id: 1, kod: 'RSD', naziv: 'Serbian Dinar' },
+  { id: 2, kod: 'EUR', naziv: 'Euro' },
+  { id: 3, kod: 'USD', naziv: 'US Dollar' },
+  { id: 4, kod: 'CHF', naziv: 'Swiss Franc' },
+  { id: 5, kod: 'GBP', naziv: 'British Pound' },
+  { id: 6, kod: 'JPY', naziv: 'Japanese Yen' },
+  { id: 7, kod: 'CAD', naziv: 'Canadian Dollar' },
+  { id: 8, kod: 'AUD', naziv: 'Australian Dollar' },
+]
+
+export interface CreateAccountPayload {
+  clientId: number
+  firmaId?: number
+  currencyId: number
+  tip: string   // 'tekuci' | 'devizni'
+  vrsta: string // 'licni' | 'poslovni'
+  naziv?: string
+}
+
+export interface AccountProto {
+  id: string
+  brojRacuna: string
+  clientId: string
+  firmaId: string
+  currencyId: string
+  currencyKod: string
+  tip: string
+  vrsta: string
+  stanje: number
+  raspolozivoStanje: number
+  dnevniLimit: number
+  mesecniLimit: number
+  naziv: string
+  status: string
+}
+
+export const accountApi = {
+  create: (data: CreateAccountPayload) =>
+    api.post('/accounts', {
+      client_id:   data.clientId,
+      firma_id:    data.firmaId ?? 0,
+      currency_id: data.currencyId,
+      tip:         data.tip,
+      vrsta:       data.vrsta,
+      naziv:       data.naziv ?? '',
+    }),
+
+  get: (id: string) => api.get(`/accounts/${id}`),
+
+  listByClient: (clientId: string) => api.get(`/accounts/client/${clientId}`),
+
+  listAll: (params: {
+    clientName?: string
+    tip?: string
+    vrsta?: string
+    status?: string
+    currencyId?: number
+    page?: number
+    pageSize?: number
+  }) => api.get('/accounts', { params: {
+    client_name:  params.clientName,
+    tip:          params.tip,
+    vrsta:        params.vrsta,
+    status:       params.status,
+    currency_id:  params.currencyId,
+    page:         params.page,
+    page_size:    params.pageSize,
+  }}),
+
+  updateName: (id: string, naziv: string) =>
+    api.put(`/accounts/${id}/name`, { naziv }),
+
+  updateLimits: (id: string, dnevniLimit: number, mesecniLimit: number) =>
+    api.put(`/accounts/${id}/limits`, { dnevni_limit: dnevniLimit, mesecni_limit: mesecniLimit }),
+}

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -35,6 +35,10 @@ const router = createRouter({
       path: '/clients',
       component: () => import('../views/ClientManagementView.vue'),
     },
+    {
+      path: '/accounts/new',
+      component: () => import('../views/CreateAccountView.vue'),
+    },
     ...clientRoutes,
   ],
 })

--- a/src/stores/account.ts
+++ b/src/stores/account.ts
@@ -1,0 +1,31 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import { accountApi, type CreateAccountPayload, type AccountProto } from '../api/account'
+
+export const useAccountStore = defineStore('account', () => {
+  const lastCreated = ref<AccountProto | null>(null)
+  const loading = ref(false)
+  const error = ref('')
+
+  async function createAccount(data: CreateAccountPayload): Promise<AccountProto> {
+    loading.value = true
+    error.value = ''
+    try {
+      const res = await accountApi.create(data)
+      const account = res.data.account
+      lastCreated.value = account
+      return account
+    } catch (e: any) {
+      error.value = e.response?.data?.message || 'Failed to create account.'
+      throw e
+    } finally {
+      loading.value = false
+    }
+  }
+
+  function clearError() {
+    error.value = ''
+  }
+
+  return { lastCreated, loading, error, createAccount, clearError }
+})

--- a/src/views/CreateAccountView.vue
+++ b/src/views/CreateAccountView.vue
@@ -1,0 +1,173 @@
+<script setup lang="ts">
+import { ref, computed } from 'vue'
+import { useRouter } from 'vue-router'
+import { useAccountStore } from '../stores/account'
+import { CURRENCIES } from '../api/account'
+import ClientSelectDialog from '../components/ClientSelectDialog.vue'
+
+const router = useRouter()
+const store = useAccountStore()
+
+const showClientDialog = ref(false)
+const selectedClientId = ref<string | null>(null)
+const selectedClientLabel = ref('')
+
+const form = ref({
+  currencyId: 1,   // RSD default
+  tip: 'tekuci',
+  vrsta: 'licni',
+  firmaId: '',
+  naziv: '',
+})
+
+const availableCurrencies = computed(() => {
+  if (form.value.tip === 'devizni') {
+    return CURRENCIES.filter(c => c.kod !== 'RSD')
+  }
+  return CURRENCIES
+})
+
+function onClientSelected(clientId: string, label?: string) {
+  selectedClientId.value = clientId
+  selectedClientLabel.value = label ?? `Client #${clientId}`
+  showClientDialog.value = false
+}
+
+function onTipChange() {
+  // devizni cannot use RSD — switch to EUR if RSD selected
+  if (form.value.tip === 'devizni' && form.value.currencyId === 1) {
+    form.value.currencyId = 2
+  }
+}
+
+async function handleSubmit() {
+  if (!selectedClientId.value) {
+    store.error = 'Please select a client.'
+    return
+  }
+  if (form.value.vrsta === 'poslovni' && !form.value.firmaId) {
+    store.error = 'Firma ID is required for poslovni accounts.'
+    return
+  }
+
+  try {
+    await store.createAccount({
+      clientId:   Number(selectedClientId.value),
+      currencyId: form.value.currencyId,
+      tip:        form.value.tip,
+      vrsta:      form.value.vrsta,
+      firmaId:    form.value.vrsta === 'poslovni' ? Number(form.value.firmaId) : undefined,
+      naziv:      form.value.naziv || undefined,
+    })
+    router.push('/accounts')
+  } catch {
+    // error is set by store
+  }
+}
+</script>
+
+<template>
+  <div class="page-content">
+    <div class="page-header">
+      <h1>Create Account</h1>
+    </div>
+
+    <div class="card" style="max-width:600px">
+      <!-- Client selection -->
+      <div class="form-group" style="margin-bottom:20px">
+        <label>Client *</label>
+        <div style="display:flex;align-items:center;gap:12px">
+          <span v-if="selectedClientId" style="flex:1;padding:8px 12px;border:1px solid #d1d5db;border-radius:6px;background:#f9fafb">
+            {{ selectedClientLabel }}
+          </span>
+          <span v-else style="flex:1;padding:8px 12px;border:1px solid #d1d5db;border-radius:6px;color:#9ca3af">
+            No client selected
+          </span>
+          <button class="btn-secondary" type="button" @click="showClientDialog = true">
+            {{ selectedClientId ? 'Change' : 'Select Client' }}
+          </button>
+        </div>
+      </div>
+
+      <!-- Currency -->
+      <div class="form-group" style="margin-bottom:20px">
+        <label>Currency *</label>
+        <select v-model="form.currencyId">
+          <option v-for="c in availableCurrencies" :key="c.id" :value="c.id">
+            {{ c.kod }} — {{ c.naziv }}
+          </option>
+        </select>
+      </div>
+
+      <!-- Tip -->
+      <div class="form-group" style="margin-bottom:20px">
+        <label>Account Type *</label>
+        <div style="display:flex;gap:24px;margin-top:6px">
+          <label style="display:flex;align-items:center;gap:8px;cursor:pointer">
+            <input type="radio" v-model="form.tip" value="tekuci" @change="onTipChange" />
+            Tekući (current)
+          </label>
+          <label style="display:flex;align-items:center;gap:8px;cursor:pointer">
+            <input type="radio" v-model="form.tip" value="devizni" @change="onTipChange" />
+            Devizni (foreign currency)
+          </label>
+        </div>
+      </div>
+
+      <!-- Vrsta -->
+      <div class="form-group" style="margin-bottom:20px">
+        <label>Account Kind *</label>
+        <div style="display:flex;gap:24px;margin-top:6px">
+          <label style="display:flex;align-items:center;gap:8px;cursor:pointer">
+            <input type="radio" v-model="form.vrsta" value="licni" />
+            Lični (personal)
+          </label>
+          <label style="display:flex;align-items:center;gap:8px;cursor:pointer">
+            <input type="radio" v-model="form.vrsta" value="poslovni" />
+            Poslovni (business)
+          </label>
+        </div>
+      </div>
+
+      <!-- Firma ID (only for poslovni) -->
+      <div v-if="form.vrsta === 'poslovni'" class="form-group" style="margin-bottom:20px">
+        <label>Firma ID *</label>
+        <input
+          v-model="form.firmaId"
+          type="number"
+          placeholder="Enter Firma ID"
+          min="1"
+        />
+      </div>
+
+      <!-- Account Name (optional) -->
+      <div class="form-group" style="margin-bottom:20px">
+        <label>Account Name (optional)</label>
+        <input v-model="form.naziv" placeholder="e.g. My savings account" />
+      </div>
+
+      <!-- Card checkbox — disabled Sprint 2 guardrail -->
+      <div class="form-group" style="margin-bottom:24px;flex-direction:row;align-items:center;gap:10px">
+        <input type="checkbox" id="card-checkbox" disabled style="width:16px;height:16px" />
+        <label for="card-checkbox" style="margin:0;color:#9ca3af">
+          Issue debit card (available in Sprint 3)
+        </label>
+      </div>
+
+      <p v-if="store.error" class="global-error" style="margin-bottom:16px">{{ store.error }}</p>
+
+      <div style="display:flex;gap:12px">
+        <button class="btn-secondary" type="button" @click="router.push('/accounts')">Cancel</button>
+        <button class="btn-primary" type="button" :disabled="store.loading" @click="handleSubmit">
+          {{ store.loading ? 'Creating...' : 'Create Account' }}
+        </button>
+      </div>
+    </div>
+  </div>
+
+  <ClientSelectDialog
+    v-if="showClientDialog"
+    @close="showClientDialog = false"
+    @selected="onClientSelected"
+  />
+</template>


### PR DESCRIPTION
Implements Issue #33 (ACCOUNT-FE-7/GH#11):

- `src/api/account.ts` — createAccount, listAll, get, updateName, updateLimits + static CURRENCIES list (8 currencies matching seed order)
- `src/stores/account.ts` — Pinia store with createAccount, loading/error state
- `src/views/CreateAccountView.vue` — employee form:
  - Client selector via `ClientSelectDialog`
  - Currency dropdown (filtered: devizni hides RSD)
  - Tip radio: tekući / devizni
  - Vrsta radio: lični / poslovni
  - Firma ID input shown only for poslovni
  - Optional account name
  - Card checkbox disabled (Sprint 2 guardrail)
- Route `/accounts/new` added
- 4 store tests + 10 view tests (44 total, all GREEN)

Fixes #11