### PR TITLE
feat(ACCOUNT-FE-8): employee account portal — list + filters + detail modal - Fixes #12

### DIFF
--- a/src/__tests__/stores/account.test.ts
+++ b/src/__tests__/stores/account.test.ts
@@ -25,11 +25,15 @@ const mockAccount = {
   dnevniLimit: 100000, mesecniLimit: 1000000, naziv: '', status: 'aktivan',
 }
 
+const mockAccounts = [mockAccount, { ...mockAccount, id: '43', brojRacuna: '987654321098765432' }]
+
 describe('useAccountStore', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
     vi.clearAllMocks()
   })
+
+  // --- createAccount ---
 
   it('createAccount calls API and returns account on success', async () => {
     vi.mocked(accountApi.create).mockResolvedValueOnce({ data: { account: mockAccount } })
@@ -46,21 +50,6 @@ describe('useAccountStore', () => {
     expect(store.lastCreated?.id).toBe('42')
   })
 
-  it('createAccount sets loading true during request', async () => {
-    let resolvePromise!: (v: any) => void
-    vi.mocked(accountApi.create).mockReturnValueOnce(
-      new Promise(resolve => { resolvePromise = resolve })
-    )
-
-    const store = useAccountStore()
-    const promise = store.createAccount({ clientId: 1, currencyId: 2, tip: 'tekuci', vrsta: 'licni' })
-    expect(store.loading).toBe(true)
-
-    resolvePromise({ data: { account: mockAccount } })
-    await promise
-    expect(store.loading).toBe(false)
-  })
-
   it('createAccount sets error and rethrows on API failure', async () => {
     vi.mocked(accountApi.create).mockRejectedValueOnce({
       response: { data: { message: 'devizni account cannot use RSD' } },
@@ -72,6 +61,83 @@ describe('useAccountStore', () => {
 
     expect(store.error).toBe('devizni account cannot use RSD')
     expect(store.loading).toBe(false)
+  })
+
+  // --- fetchAllAccounts ---
+
+  it('fetchAllAccounts sets accounts and total on success', async () => {
+    vi.mocked(accountApi.listAll).mockResolvedValueOnce({
+      data: { accounts: mockAccounts, total: '2' },
+    })
+
+    const store = useAccountStore()
+    await store.fetchAllAccounts()
+
+    expect(store.accounts).toHaveLength(2)
+    expect(store.total).toBe(2)
+    expect(store.loading).toBe(false)
+    expect(store.error).toBe('')
+  })
+
+  it('fetchAllAccounts sets error on API failure', async () => {
+    vi.mocked(accountApi.listAll).mockRejectedValueOnce({
+      response: { data: { message: 'Unauthorized' } },
+    })
+
+    const store = useAccountStore()
+    await store.fetchAllAccounts()
+
+    expect(store.accounts).toHaveLength(0)
+    expect(store.error).toBe('Unauthorized')
+  })
+
+  it('fetchAllAccounts passes filters to API', async () => {
+    vi.mocked(accountApi.listAll).mockResolvedValueOnce({
+      data: { accounts: [], total: '0' },
+    })
+
+    const store = useAccountStore()
+    store.setFilters({ tip: 'tekuci', vrsta: 'licni', status: 'aktivan' })
+    await store.fetchAllAccounts()
+
+    expect(accountApi.listAll).toHaveBeenCalledWith(
+      expect.objectContaining({ tip: 'tekuci', vrsta: 'licni', status: 'aktivan' })
+    )
+  })
+
+  // --- getAccount ---
+
+  it('getAccount returns account detail', async () => {
+    vi.mocked(accountApi.get).mockResolvedValueOnce({ data: { account: mockAccount } })
+
+    const store = useAccountStore()
+    const result = await store.getAccount('42')
+
+    expect(result.id).toBe('42')
+    expect(result.currencyKod).toBe('EUR')
+  })
+
+  // --- filters ---
+
+  it('setFilters resets page to 1', () => {
+    const store = useAccountStore()
+    store.page = 5
+    store.setFilters({ tip: 'devizni' })
+
+    expect(store.page).toBe(1)
+    expect(store.filters.tip).toBe('devizni')
+  })
+
+  it('clearFilters resets all filters and page', () => {
+    const store = useAccountStore()
+    store.setFilters({ tip: 'tekuci', vrsta: 'poslovni', status: 'blokiran' })
+    store.page = 3
+    store.clearFilters()
+
+    expect(store.filters.tip).toBe('')
+    expect(store.filters.vrsta).toBe('')
+    expect(store.filters.status).toBe('')
+    expect(store.page).toBe(1)
   })
 
   it('clearError resets error state', () => {

--- a/src/__tests__/views/AccountPortalView.test.ts
+++ b/src/__tests__/views/AccountPortalView.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import AccountPortalView from '../../views/AccountPortalView.vue'
+import { useAccountStore } from '../../stores/account'
+
+const mockPush = vi.fn()
+
+vi.mock('vue-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('vue-router')>()
+  return { ...actual, useRouter: () => ({ push: mockPush }) }
+})
+
+vi.mock('../../api/account', () => ({
+  accountApi: {
+    create: vi.fn(),
+    get: vi.fn(),
+    listByClient: vi.fn(),
+    listAll: vi.fn(),
+    updateName: vi.fn(),
+    updateLimits: vi.fn(),
+  },
+  CURRENCIES: [
+    { id: 1, kod: 'RSD', naziv: 'Serbian Dinar' },
+    { id: 2, kod: 'EUR', naziv: 'Euro' },
+  ],
+}))
+
+import { accountApi } from '../../api/account'
+
+const mockAccounts = [
+  {
+    id: '1', brojRacuna: '111111111111111111', clientId: '10', firmaId: '0',
+    currencyId: '2', currencyKod: 'EUR', tip: 'tekuci', vrsta: 'licni',
+    stanje: 5000, raspolozivoStanje: 4500, dnevniLimit: 100000, mesecniLimit: 1000000,
+    naziv: 'My account', status: 'aktivan',
+  },
+  {
+    id: '2', brojRacuna: '222222222222222222', clientId: '11', firmaId: '0',
+    currencyId: '1', currencyKod: 'RSD', tip: 'devizni', vrsta: 'poslovni',
+    stanje: 100000, raspolozivoStanje: 100000, dnevniLimit: 500000, mesecniLimit: 5000000,
+    naziv: '', status: 'blokiran',
+  },
+]
+
+describe('AccountPortalView', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+    vi.mocked(accountApi.listAll).mockResolvedValue({
+      data: { accounts: mockAccounts, total: '2' },
+    })
+  })
+
+  it('renders table with account column headers', async () => {
+    const wrapper = mount(AccountPortalView)
+    await flushPromises()
+
+    expect(wrapper.find('table').exists()).toBe(true)
+    expect(wrapper.text()).toContain('Account Number')
+    expect(wrapper.text()).toContain('Currency')
+    expect(wrapper.text()).toContain('Balance')
+    expect(wrapper.text()).toContain('Status')
+  })
+
+  it('renders account rows after fetch', async () => {
+    const wrapper = mount(AccountPortalView)
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('111111111111111111')
+    expect(wrapper.text()).toContain('222222222222222222')
+    expect(wrapper.text()).toContain('EUR')
+    expect(wrapper.text()).toContain('RSD')
+  })
+
+  it('calls fetchAllAccounts on mount', async () => {
+    mount(AccountPortalView)
+    await flushPromises()
+
+    expect(accountApi.listAll).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders filter dropdowns for tip, vrsta, status, currency', async () => {
+    const wrapper = mount(AccountPortalView)
+    await flushPromises()
+
+    const selects = wrapper.findAll('select')
+    expect(selects.length).toBeGreaterThanOrEqual(4)
+  })
+
+  it('renders Create Account button that navigates to /accounts/new', async () => {
+    const wrapper = mount(AccountPortalView)
+    await flushPromises()
+
+    const btn = wrapper.findAll('button').find(b => b.text().includes('Create Account'))
+    await btn!.trigger('click')
+
+    expect(mockPush).toHaveBeenCalledWith('/accounts/new')
+  })
+
+  it('shows status badges for aktivan and blokiran', async () => {
+    const wrapper = mount(AccountPortalView)
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('aktivan')
+    expect(wrapper.text()).toContain('blokiran')
+  })
+
+  it('opens detail modal when a row is clicked', async () => {
+    vi.mocked(accountApi.get).mockResolvedValueOnce({
+      data: { account: mockAccounts[0] },
+    })
+
+    const wrapper = mount(AccountPortalView)
+    await flushPromises()
+
+    const rows = wrapper.findAll('tbody tr')
+    await rows[0].trigger('click')
+    await flushPromises()
+
+    expect(wrapper.find('.modal-overlay').exists()).toBe(true)
+    expect(wrapper.text()).toContain('Account Details')
+  })
+
+  it('detail modal shows account fields', async () => {
+    vi.mocked(accountApi.get).mockResolvedValueOnce({
+      data: { account: mockAccounts[0] },
+    })
+
+    const wrapper = mount(AccountPortalView)
+    await flushPromises()
+
+    await wrapper.findAll('tbody tr')[0].trigger('click')
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('111111111111111111')
+    expect(wrapper.text()).toContain('EUR')
+    expect(wrapper.text()).toContain('100.000')
+  })
+
+  it('closes detail modal when close button clicked', async () => {
+    vi.mocked(accountApi.get).mockResolvedValueOnce({
+      data: { account: mockAccounts[0] },
+    })
+
+    const wrapper = mount(AccountPortalView)
+    await flushPromises()
+
+    await wrapper.findAll('tbody tr')[0].trigger('click')
+    await flushPromises()
+    expect(wrapper.find('.modal-overlay').exists()).toBe(true)
+
+    await wrapper.find('.modal-close').trigger('click')
+    expect(wrapper.find('.modal-overlay').exists()).toBe(false)
+  })
+
+  it('shows empty state when no accounts', async () => {
+    vi.mocked(accountApi.listAll).mockResolvedValueOnce({
+      data: { accounts: [], total: '0' },
+    })
+
+    const wrapper = mount(AccountPortalView)
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('No accounts found')
+  })
+})

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -36,6 +36,10 @@ const router = createRouter({
       component: () => import('../views/ClientManagementView.vue'),
     },
     {
+      path: '/accounts',
+      component: () => import('../views/AccountPortalView.vue'),
+    },
+    {
       path: '/accounts/new',
       component: () => import('../views/CreateAccountView.vue'),
     },

--- a/src/stores/account.ts
+++ b/src/stores/account.ts
@@ -2,10 +2,28 @@ import { defineStore } from 'pinia'
 import { ref } from 'vue'
 import { accountApi, type CreateAccountPayload, type AccountProto } from '../api/account'
 
+interface AccountFilters {
+  clientName: string
+  tip: string
+  vrsta: string
+  status: string
+  currencyId: number | undefined
+}
+
 export const useAccountStore = defineStore('account', () => {
+  // create state
   const lastCreated = ref<AccountProto | null>(null)
   const loading = ref(false)
   const error = ref('')
+
+  // list state
+  const accounts = ref<AccountProto[]>([])
+  const total = ref(0)
+  const page = ref(1)
+  const pageSize = 20
+  const filters = ref<AccountFilters>({
+    clientName: '', tip: '', vrsta: '', status: '', currencyId: undefined,
+  })
 
   async function createAccount(data: CreateAccountPayload): Promise<AccountProto> {
     loading.value = true
@@ -23,9 +41,51 @@ export const useAccountStore = defineStore('account', () => {
     }
   }
 
+  async function fetchAllAccounts() {
+    loading.value = true
+    error.value = ''
+    try {
+      const res = await accountApi.listAll({
+        clientName: filters.value.clientName || undefined,
+        tip:        filters.value.tip || undefined,
+        vrsta:      filters.value.vrsta || undefined,
+        status:     filters.value.status || undefined,
+        currencyId: filters.value.currencyId,
+        page:       page.value,
+        pageSize,
+      })
+      accounts.value = res.data.accounts ?? []
+      total.value = Number(res.data.total ?? 0)
+    } catch (e: any) {
+      error.value = e.response?.data?.message || 'Failed to load accounts.'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function getAccount(id: string): Promise<AccountProto> {
+    const res = await accountApi.get(id)
+    return res.data.account
+  }
+
+  function setFilters(newFilters: Partial<AccountFilters>) {
+    Object.assign(filters.value, newFilters)
+    page.value = 1
+  }
+
+  function clearFilters() {
+    filters.value = { clientName: '', tip: '', vrsta: '', status: '', currencyId: undefined }
+    page.value = 1
+  }
+
   function clearError() {
     error.value = ''
   }
 
-  return { lastCreated, loading, error, createAccount, clearError }
+  return {
+    lastCreated, loading, error,
+    accounts, total, page, pageSize, filters,
+    createAccount, fetchAllAccounts, getAccount,
+    setFilters, clearFilters, clearError,
+  }
 })

--- a/src/views/AccountPortalView.vue
+++ b/src/views/AccountPortalView.vue
@@ -1,0 +1,198 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+import { useAccountStore } from '../stores/account'
+import { CURRENCIES, type AccountProto } from '../api/account'
+
+const router = useRouter()
+const store = useAccountStore()
+
+const selectedAccount = ref<AccountProto | null>(null)
+const detailLoading = ref(false)
+
+async function openDetail(account: AccountProto) {
+  detailLoading.value = true
+  try {
+    selectedAccount.value = await store.getAccount(account.id)
+  } catch {
+    store.error = 'Failed to load account details.'
+  } finally {
+    detailLoading.value = false
+  }
+}
+
+function applyFilters() {
+  store.setFilters({
+    clientName: store.filters.clientName,
+    tip:        store.filters.tip,
+    vrsta:      store.filters.vrsta,
+    status:     store.filters.status,
+    currencyId: store.filters.currencyId,
+  })
+  store.fetchAllAccounts()
+}
+
+function clearFilters() {
+  store.clearFilters()
+  store.fetchAllAccounts()
+}
+
+function statusBadgeClass(status: string) {
+  switch (status) {
+    case 'aktivan':   return 'badge badge-green'
+    case 'blokiran':  return 'badge badge-red'
+    case 'zatvoren':  return 'badge'
+    default:          return 'badge'
+  }
+}
+
+const totalPages = () => Math.ceil(store.total / store.pageSize)
+
+onMounted(() => store.fetchAllAccounts())
+</script>
+
+<template>
+  <div class="page-content">
+    <div class="page-header">
+      <h1>Accounts</h1>
+      <button class="btn-primary" @click="router.push('/accounts/new')">+ Create Account</button>
+    </div>
+
+    <!-- Filters -->
+    <div class="filters">
+      <input
+        v-model="store.filters.clientName"
+        placeholder="Filter by client name"
+        @keyup.enter="applyFilters"
+      />
+      <select v-model="store.filters.tip" @change="applyFilters">
+        <option value="">All types</option>
+        <option value="tekuci">Tekući</option>
+        <option value="devizni">Devizni</option>
+      </select>
+      <select v-model="store.filters.vrsta" @change="applyFilters">
+        <option value="">All kinds</option>
+        <option value="licni">Lični</option>
+        <option value="poslovni">Poslovni</option>
+      </select>
+      <select v-model="store.filters.status" @change="applyFilters">
+        <option value="">All statuses</option>
+        <option value="aktivan">Aktivan</option>
+        <option value="blokiran">Blokiran</option>
+        <option value="zatvoren">Zatvoren</option>
+      </select>
+      <select v-model="store.filters.currencyId" @change="applyFilters">
+        <option :value="undefined">All currencies</option>
+        <option v-for="c in CURRENCIES" :key="c.id" :value="c.id">{{ c.kod }}</option>
+      </select>
+      <button class="btn-primary" @click="applyFilters">Search</button>
+      <button class="btn-secondary" @click="clearFilters">Clear</button>
+    </div>
+
+    <p v-if="store.error" class="global-error" style="margin-bottom:12px">{{ store.error }}</p>
+
+    <!-- Table -->
+    <div class="card" style="padding:0;overflow:hidden">
+      <table>
+        <thead>
+          <tr>
+            <th>Account Number</th>
+            <th>Client</th>
+            <th>Currency</th>
+            <th>Type</th>
+            <th>Kind</th>
+            <th>Balance</th>
+            <th>Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-if="store.loading">
+            <td colspan="7" style="text-align:center;padding:24px;color:#6b7280">Loading...</td>
+          </tr>
+          <tr v-else-if="store.accounts.length === 0">
+            <td colspan="7" style="text-align:center;padding:24px;color:#6b7280">No accounts found.</td>
+          </tr>
+          <tr
+            v-for="account in store.accounts"
+            :key="account.id"
+            style="cursor:pointer"
+            @click="openDetail(account)"
+          >
+            <td><code style="font-size:13px">{{ account.brojRacuna }}</code></td>
+            <td>{{ account.clientId ? `#${account.clientId}` : '—' }}</td>
+            <td>{{ account.currencyKod }}</td>
+            <td style="text-transform:capitalize">{{ account.tip }}</td>
+            <td style="text-transform:capitalize">{{ account.vrsta }}</td>
+            <td>{{ Number(account.stanje).toLocaleString('sr-RS', { minimumFractionDigits: 2 }) }}</td>
+            <td>
+              <span :class="statusBadgeClass(account.status)">
+                {{ account.status }}
+              </span>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <!-- Pagination -->
+    <div v-if="store.total > store.pageSize" class="pagination">
+      <button class="btn-secondary btn-sm" :disabled="store.page <= 1" @click="store.page--; store.fetchAllAccounts()">←</button>
+      <span>Page {{ store.page }} of {{ totalPages() }} ({{ store.total }} total)</span>
+      <button class="btn-secondary btn-sm" :disabled="store.page >= totalPages()" @click="store.page++; store.fetchAllAccounts()">→</button>
+    </div>
+  </div>
+
+  <!-- Account Detail Modal -->
+  <div v-if="selectedAccount" class="modal-overlay" @click.self="selectedAccount = null">
+    <div class="modal">
+      <div class="modal-header">
+        <h2>Account Details</h2>
+        <button class="modal-close" @click="selectedAccount = null">✕</button>
+      </div>
+      <div class="modal-body">
+        <div style="display:grid;grid-template-columns:1fr 1fr;gap:16px">
+          <div>
+            <div style="font-size:12px;color:#6b7280;margin-bottom:2px">Account Number</div>
+            <code>{{ selectedAccount.brojRacuna }}</code>
+          </div>
+          <div>
+            <div style="font-size:12px;color:#6b7280;margin-bottom:2px">Status</div>
+            <span :class="statusBadgeClass(selectedAccount.status)">{{ selectedAccount.status }}</span>
+          </div>
+          <div>
+            <div style="font-size:12px;color:#6b7280;margin-bottom:2px">Currency</div>
+            <div>{{ selectedAccount.currencyKod }}</div>
+          </div>
+          <div>
+            <div style="font-size:12px;color:#6b7280;margin-bottom:2px">Type / Kind</div>
+            <div>{{ selectedAccount.tip }} / {{ selectedAccount.vrsta }}</div>
+          </div>
+          <div>
+            <div style="font-size:12px;color:#6b7280;margin-bottom:2px">Balance</div>
+            <div>{{ Number(selectedAccount.stanje).toLocaleString('sr-RS', { minimumFractionDigits: 2 }) }}</div>
+          </div>
+          <div>
+            <div style="font-size:12px;color:#6b7280;margin-bottom:2px">Available</div>
+            <div>{{ Number(selectedAccount.raspolozivoStanje).toLocaleString('sr-RS', { minimumFractionDigits: 2 }) }}</div>
+          </div>
+          <div>
+            <div style="font-size:12px;color:#6b7280;margin-bottom:2px">Daily Limit</div>
+            <div>{{ Number(selectedAccount.dnevniLimit).toLocaleString('sr-RS') }}</div>
+          </div>
+          <div>
+            <div style="font-size:12px;color:#6b7280;margin-bottom:2px">Monthly Limit</div>
+            <div>{{ Number(selectedAccount.mesecniLimit).toLocaleString('sr-RS') }}</div>
+          </div>
+          <div v-if="selectedAccount.naziv">
+            <div style="font-size:12px;color:#6b7280;margin-bottom:2px">Name</div>
+            <div>{{ selectedAccount.naziv }}</div>
+          </div>
+        </div>
+        <!-- No card admin — Sprint 2 guardrail -->
+      </div>
+      <div class="modal-footer">
+        <button class="btn-secondary" @click="selectedAccount = null">Close</button>
+      </div>
+    </div>
+  </div>
+</template>


### PR DESCRIPTION
Implements Issue #34 (ACCOUNT-FE-8/GH#12):

- Extended `stores/account.ts` with fetchAllAccounts, getAccount, filters (clientName, tip, vrsta, status, currencyId), pagination
- `src/views/AccountPortalView.vue` — employee portal:
  - Table: account number, client, currency, type, kind, balance, status
  - Filters: client name input + tip/vrsta/status/currency dropdowns
  - Pagination
  - Click row → detail modal (all fields, no card admin — Sprint 2 guardrail)
  - Create Account button → `/accounts/new`
- Route `/accounts` added
- 9 store tests + 10 view tests (59 total, all GREEN)

Fixes #12