### PR TITLE
feat(ACCOUNT-FE-9): client accounts page — balance, limits, transfer/payment entry points - Fixes #13

### DIFF
--- a/src/__tests__/stores/clientAccount.test.ts
+++ b/src/__tests__/stores/clientAccount.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useClientAccountStore } from '../../stores/clientAccount'
+import { clientAccountApi } from '../../api/clientAccount'
+
+vi.mock('../../api/clientAccount', () => ({
+  clientAccountApi: {
+    listByClient: vi.fn(),
+    get: vi.fn(),
+  },
+}))
+
+const mockAccounts = [
+  {
+    id: '1', brojRacuna: '111111111111111111', clientId: '5', firmaId: '0',
+    currencyId: '2', currencyKod: 'EUR', tip: 'tekuci', vrsta: 'licni',
+    stanje: 5000, raspolozivoStanje: 4500, dnevniLimit: 100000, mesecniLimit: 1000000,
+    naziv: 'My EUR account', status: 'aktivan',
+  },
+  {
+    id: '2', brojRacuna: '222222222222222222', clientId: '5', firmaId: '0',
+    currencyId: '1', currencyKod: 'RSD', tip: 'tekuci', vrsta: 'licni',
+    stanje: 50000, raspolozivoStanje: 50000, dnevniLimit: 100000, mesecniLimit: 1000000,
+    naziv: '', status: 'aktivan',
+  },
+]
+
+describe('useClientAccountStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('fetchAccounts sets accounts on success', async () => {
+    vi.mocked(clientAccountApi.listByClient).mockResolvedValueOnce({
+      data: { accounts: mockAccounts },
+    })
+
+    const store = useClientAccountStore()
+    await store.fetchAccounts('5')
+
+    expect(store.accounts).toHaveLength(2)
+    expect(store.loading).toBe(false)
+    expect(store.error).toBe('')
+  })
+
+  it('fetchAccounts calls API with correct clientId', async () => {
+    vi.mocked(clientAccountApi.listByClient).mockResolvedValueOnce({
+      data: { accounts: [] },
+    })
+
+    const store = useClientAccountStore()
+    await store.fetchAccounts('42')
+
+    expect(clientAccountApi.listByClient).toHaveBeenCalledWith('42')
+  })
+
+  it('fetchAccounts sets error on API failure', async () => {
+    vi.mocked(clientAccountApi.listByClient).mockRejectedValueOnce({
+      response: { data: { message: 'Unauthorized' } },
+    })
+
+    const store = useClientAccountStore()
+    await store.fetchAccounts('5')
+
+    expect(store.accounts).toHaveLength(0)
+    expect(store.error).toBe('Unauthorized')
+    expect(store.loading).toBe(false)
+  })
+
+  it('sets loading true during fetch and false after', async () => {
+    let resolve!: (v: any) => void
+    vi.mocked(clientAccountApi.listByClient).mockReturnValueOnce(
+      new Promise(r => { resolve = r })
+    )
+
+    const store = useClientAccountStore()
+    const promise = store.fetchAccounts('5')
+    expect(store.loading).toBe(true)
+
+    resolve({ data: { accounts: [] } })
+    await promise
+    expect(store.loading).toBe(false)
+  })
+})

--- a/src/__tests__/views/ClientAccountsView.test.ts
+++ b/src/__tests__/views/ClientAccountsView.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import ClientAccountsView from '../../views/client/ClientAccountsView.vue'
+import { useClientAccountStore } from '../../stores/clientAccount'
+import { useClientAuthStore } from '../../stores/clientAuth'
+
+const mockPush = vi.fn()
+
+vi.mock('vue-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('vue-router')>()
+  return { ...actual, useRouter: () => ({ push: mockPush }) }
+})
+
+vi.mock('../../api/clientAccount', () => ({
+  clientAccountApi: { listByClient: vi.fn(), get: vi.fn() },
+}))
+
+vi.mock('../../api/clientAuth', () => ({
+  clientAuthApi: { login: vi.fn() },
+  default: { get: vi.fn(), interceptors: { request: { use: vi.fn() } } },
+}))
+
+import { clientAccountApi } from '../../api/clientAccount'
+
+const mockAccounts = [
+  {
+    id: '1', brojRacuna: '111111111111111111', clientId: '5', firmaId: '0',
+    currencyId: '2', currencyKod: 'EUR', tip: 'tekuci', vrsta: 'licni',
+    stanje: 5000, raspolozivoStanje: 4500, dnevniLimit: 100000, mesecniLimit: 1000000,
+    naziv: 'My EUR account', status: 'aktivan',
+  },
+  {
+    id: '2', brojRacuna: '222222222222222222', clientId: '5', firmaId: '0',
+    currencyId: '1', currencyKod: 'RSD', tip: 'tekuci', vrsta: 'licni',
+    stanje: 50000, raspolozivoStanje: 50000, dnevniLimit: 100000, mesecniLimit: 1000000,
+    naziv: '', status: 'blokiran',
+  },
+]
+
+describe('ClientAccountsView', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+
+    // Set up logged-in client
+    const authStore = useClientAuthStore()
+    authStore.accessToken = 'test-token'
+    authStore.client = { id: '5', ime: 'Ana', prezime: 'Jović', email: 'ana@gmail.com', permissions: ['client.basic'] }
+
+    vi.mocked(clientAccountApi.listByClient).mockResolvedValue({
+      data: { accounts: mockAccounts },
+    })
+  })
+
+  it('renders My Accounts heading', async () => {
+    const wrapper = mount(ClientAccountsView)
+    await flushPromises()
+    expect(wrapper.text()).toContain('My Accounts')
+  })
+
+  it('calls fetchAccounts with client id on mount', async () => {
+    mount(ClientAccountsView)
+    await flushPromises()
+    expect(clientAccountApi.listByClient).toHaveBeenCalledWith('5')
+  })
+
+  it('renders an account card for each account', async () => {
+    const wrapper = mount(ClientAccountsView)
+    await flushPromises()
+    const cards = wrapper.findAll('.account-card')
+    expect(cards).toHaveLength(2)
+  })
+
+  it('shows account number on each card', async () => {
+    const wrapper = mount(ClientAccountsView)
+    await flushPromises()
+    expect(wrapper.text()).toContain('111111111111111111')
+    expect(wrapper.text()).toContain('222222222222222222')
+  })
+
+  it('shows balance and available balance', async () => {
+    const wrapper = mount(ClientAccountsView)
+    await flushPromises()
+    expect(wrapper.text()).toContain('Balance')
+    expect(wrapper.text()).toContain('Available')
+    expect(wrapper.text()).toContain('EUR')
+  })
+
+  it('shows daily and monthly limits', async () => {
+    const wrapper = mount(ClientAccountsView)
+    await flushPromises()
+    expect(wrapper.text()).toContain('Daily limit')
+    expect(wrapper.text()).toContain('Monthly limit')
+  })
+
+  it('shows account status badge', async () => {
+    const wrapper = mount(ClientAccountsView)
+    await flushPromises()
+    expect(wrapper.text()).toContain('aktivan')
+    expect(wrapper.text()).toContain('blokiran')
+  })
+
+  it('shows New Transfer and New Payment buttons', async () => {
+    const wrapper = mount(ClientAccountsView)
+    await flushPromises()
+    expect(wrapper.text()).toContain('New Transfer')
+    expect(wrapper.text()).toContain('New Payment')
+  })
+
+  it('clicking New Transfer navigates with fromAccountId', async () => {
+    const wrapper = mount(ClientAccountsView)
+    await flushPromises()
+
+    const transferBtn = wrapper.findAll('button').find(b => b.text() === 'New Transfer')
+    await transferBtn!.trigger('click')
+
+    expect(mockPush).toHaveBeenCalledWith(
+      expect.objectContaining({ path: '/client/transfers', query: expect.objectContaining({ fromAccountId: '1' }) })
+    )
+  })
+
+  it('shows empty state when no accounts', async () => {
+    vi.mocked(clientAccountApi.listByClient).mockResolvedValueOnce({ data: { accounts: [] } })
+
+    const wrapper = mount(ClientAccountsView)
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('No accounts found')
+  })
+})

--- a/src/api/clientAccount.ts
+++ b/src/api/clientAccount.ts
@@ -1,0 +1,26 @@
+import clientApi from './clientAuth'
+
+export interface ClientAccountItem {
+  id: string
+  brojRacuna: string
+  clientId: string
+  firmaId: string
+  currencyId: string
+  currencyKod: string
+  tip: string
+  vrsta: string
+  stanje: number
+  raspolozivoStanje: number
+  dnevniLimit: number
+  mesecniLimit: number
+  naziv: string
+  status: string
+}
+
+export const clientAccountApi = {
+  listByClient: (clientId: string) =>
+    clientApi.get(`/accounts/client/${clientId}`),
+
+  get: (id: string) =>
+    clientApi.get(`/accounts/${id}`),
+}

--- a/src/stores/clientAccount.ts
+++ b/src/stores/clientAccount.ts
@@ -1,0 +1,24 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import { clientAccountApi, type ClientAccountItem } from '../api/clientAccount'
+
+export const useClientAccountStore = defineStore('clientAccount', () => {
+  const accounts = ref<ClientAccountItem[]>([])
+  const loading = ref(false)
+  const error = ref('')
+
+  async function fetchAccounts(clientId: string) {
+    loading.value = true
+    error.value = ''
+    try {
+      const res = await clientAccountApi.listByClient(clientId)
+      accounts.value = res.data.accounts ?? []
+    } catch (e: any) {
+      error.value = e.response?.data?.message || 'Failed to load accounts.'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  return { accounts, loading, error, fetchAccounts }
+})

--- a/src/views/client/ClientAccountsView.vue
+++ b/src/views/client/ClientAccountsView.vue
@@ -1,9 +1,126 @@
 <script setup lang="ts">
+import { onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+import { useClientAuthStore } from '../../stores/clientAuth'
+import { useClientAccountStore } from '../../stores/clientAccount'
+import type { ClientAccountItem } from '../../api/clientAccount'
+
+const router = useRouter()
+const authStore = useClientAuthStore()
+const store = useClientAccountStore()
+
+function statusBadgeClass(status: string) {
+  switch (status) {
+    case 'aktivan':  return 'badge badge-green'
+    case 'blokiran': return 'badge badge-red'
+    default:         return 'badge'
+  }
+}
+
+function tipLabel(tip: string) {
+  return tip === 'tekuci' ? 'Tekući' : 'Devizni'
+}
+
+function vrstaLabel(vrsta: string) {
+  return vrsta === 'licni' ? 'Lični' : 'Poslovni'
+}
+
+function formatAmount(amount: number, currency: string) {
+  return `${Number(amount).toLocaleString('sr-RS', { minimumFractionDigits: 2 })} ${currency}`
+}
+
+function newTransfer(account: ClientAccountItem) {
+  router.push({ path: '/client/transfers', query: { fromAccountId: account.id } })
+}
+
+function newPayment(account: ClientAccountItem) {
+  router.push({ path: '/client/payments', query: { fromAccountId: account.id } })
+}
+
+onMounted(() => {
+  if (authStore.client?.id) {
+    store.fetchAccounts(authStore.client.id)
+  }
+})
 </script>
 
 <template>
-  <div class="page-container">
-    <h1>ClientAccountsView</h1>
-    <p>Coming soon</p>
+  <div class="page-content">
+    <div class="page-header">
+      <h1>My Accounts</h1>
+    </div>
+
+    <p v-if="store.error" class="global-error" style="margin-bottom:16px">{{ store.error }}</p>
+
+    <div v-if="store.loading" style="text-align:center;padding:40px;color:#6b7280">
+      Loading accounts...
+    </div>
+
+    <div v-else-if="store.accounts.length === 0 && !store.loading" style="text-align:center;padding:40px;color:#6b7280">
+      No accounts found.
+    </div>
+
+    <div v-else style="display:grid;gap:16px">
+      <div
+        v-for="account in store.accounts"
+        :key="account.id"
+        class="card account-card"
+        style="padding:20px"
+      >
+        <!-- Header row -->
+        <div style="display:flex;justify-content:space-between;align-items:flex-start;margin-bottom:16px">
+          <div>
+            <div style="font-size:18px;font-weight:600;margin-bottom:4px">
+              {{ account.naziv || `${tipLabel(account.tip)} account` }}
+            </div>
+            <code style="font-size:13px;color:#6b7280">{{ account.brojRacuna }}</code>
+          </div>
+          <div style="display:flex;align-items:center;gap:8px">
+            <span style="font-size:13px;color:#6b7280">{{ tipLabel(account.tip) }} · {{ vrstaLabel(account.vrsta) }}</span>
+            <span :class="statusBadgeClass(account.status)">{{ account.status }}</span>
+          </div>
+        </div>
+
+        <!-- Balance section -->
+        <div style="display:grid;grid-template-columns:1fr 1fr 1fr;gap:16px;margin-bottom:16px">
+          <div>
+            <div style="font-size:12px;color:#6b7280;margin-bottom:2px">Balance</div>
+            <div style="font-size:20px;font-weight:600">{{ formatAmount(account.stanje, account.currencyKod) }}</div>
+          </div>
+          <div>
+            <div style="font-size:12px;color:#6b7280;margin-bottom:2px">Available</div>
+            <div style="font-size:20px;font-weight:600;color:#16a34a">{{ formatAmount(account.raspolozivoStanje, account.currencyKod) }}</div>
+          </div>
+          <div>
+            <div style="font-size:12px;color:#6b7280;margin-bottom:2px">Currency</div>
+            <div style="font-size:20px;font-weight:600">{{ account.currencyKod }}</div>
+          </div>
+        </div>
+
+        <!-- Limits row -->
+        <div style="display:flex;gap:24px;font-size:13px;color:#6b7280;margin-bottom:16px">
+          <span>Daily limit: <strong style="color:#374151">{{ Number(account.dnevniLimit).toLocaleString('sr-RS') }} {{ account.currencyKod }}</strong></span>
+          <span>Monthly limit: <strong style="color:#374151">{{ Number(account.mesecniLimit).toLocaleString('sr-RS') }} {{ account.currencyKod }}</strong></span>
+        </div>
+
+        <!-- Actions -->
+        <div style="display:flex;gap:10px">
+          <button
+            class="btn-primary btn-sm"
+            :disabled="account.status !== 'aktivan'"
+            @click="newTransfer(account)"
+          >New Transfer</button>
+          <button
+            class="btn-secondary btn-sm"
+            :disabled="account.status !== 'aktivan'"
+            @click="newPayment(account)"
+          >New Payment</button>
+          <button
+            class="btn-secondary btn-sm"
+            @click="router.push({ path: '/client/transfers', query: { accountId: account.id } })"
+          >View Transactions</button>
+        </div>
+      </div>
+    </div>
   </div>
 </template>


### PR DESCRIPTION
Implements Issue #35 (ACCOUNT-FE-9/GH#13):

- `src/api/clientAccount.ts` — client-facing account API using `clientApiClient` (client JWT)
- `src/stores/clientAccount.ts` — Pinia store with fetchAccounts, loading/error state
- `src/views/client/ClientAccountsView.vue` — replaces stub:
  - Card per account: name/number, balance, available balance, currency
  - Daily/monthly limits
  - Status badge
  - Buttons: New Transfer → `/client/transfers?fromAccountId=X`, New Payment → `/client/payments?fromAccountId=X`, View Transactions
- 4 store tests + 10 view tests (73 total, all GREEN)

Fixes #13