### PR TITLE
feat(TRANSFER-FE-5): client transfers page with 3-step flow and history - Fixes #15

### DIFF
--- a/src/__tests__/stores/transfer.test.ts
+++ b/src/__tests__/stores/transfer.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useTransferStore } from '../../stores/transfer'
+import { transferApi } from '../../api/transfer'
+
+vi.mock('../../api/transfer', () => ({
+  transferApi: {
+    create: vi.fn(),
+    listByClient: vi.fn(),
+    listByAccount: vi.fn(),
+    calculateExchange: vi.fn(),
+  },
+}))
+
+const mockTransfers = [
+  {
+    id: '1',
+    racunPosiljaocaId: '10',
+    racunPrimaocaId: '20',
+    iznos: 1000,
+    valutaIznosa: 'RSD',
+    konvertovaniIznos: 1000,
+    kurs: 1,
+    svrha: 'Test',
+    status: 'uspesno',
+    vremeTransakcije: '2026-03-01T10:00:00Z',
+  },
+  {
+    id: '2',
+    racunPosiljaocaId: '10',
+    racunPrimaocaId: '30',
+    iznos: 50,
+    valutaIznosa: 'EUR',
+    konvertovaniIznos: 6000,
+    kurs: 120,
+    svrha: 'Renta',
+    status: 'uspesno',
+    vremeTransakcije: '2026-03-02T12:00:00Z',
+  },
+]
+
+describe('useTransferStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('fetchByClient sets transfers on success', async () => {
+    vi.mocked(transferApi.listByClient).mockResolvedValueOnce({
+      data: { transfers: mockTransfers, total: 2 },
+    })
+
+    const store = useTransferStore()
+    await store.fetchByClient('5')
+
+    expect(store.transfers).toHaveLength(2)
+    expect(store.total).toBe(2)
+    expect(store.loading).toBe(false)
+    expect(store.error).toBe('')
+  })
+
+  it('fetchByClient calls API with correct clientId and pagination', async () => {
+    vi.mocked(transferApi.listByClient).mockResolvedValueOnce({
+      data: { transfers: [], total: 0 },
+    })
+
+    const store = useTransferStore()
+    await store.fetchByClient('42', { status: 'uspesno' })
+
+    expect(transferApi.listByClient).toHaveBeenCalledWith('42', {
+      status: 'uspesno',
+      page: 1,
+      pageSize: 20,
+    })
+  })
+
+  it('fetchByClient sets error on API failure', async () => {
+    vi.mocked(transferApi.listByClient).mockRejectedValueOnce({
+      response: { data: { message: 'Unauthorized' } },
+    })
+
+    const store = useTransferStore()
+    await store.fetchByClient('5')
+
+    expect(store.transfers).toHaveLength(0)
+    expect(store.error).toBe('Unauthorized')
+    expect(store.loading).toBe(false)
+  })
+
+  it('fetchByAccount sets transfers on success', async () => {
+    vi.mocked(transferApi.listByAccount).mockResolvedValueOnce({
+      data: { transfers: [mockTransfers[0]], total: 1 },
+    })
+
+    const store = useTransferStore()
+    await store.fetchByAccount('10')
+
+    expect(store.transfers).toHaveLength(1)
+    expect(store.total).toBe(1)
+  })
+
+  it('fetchByAccount calls API with correct accountId', async () => {
+    vi.mocked(transferApi.listByAccount).mockResolvedValueOnce({
+      data: { transfers: [], total: 0 },
+    })
+
+    const store = useTransferStore()
+    await store.fetchByAccount('99')
+
+    expect(transferApi.listByAccount).toHaveBeenCalledWith('99', expect.objectContaining({ page: 1 }))
+  })
+
+  it('createTransfer returns created transfer', async () => {
+    vi.mocked(transferApi.create).mockResolvedValueOnce({
+      data: { transfer: mockTransfers[0] },
+    })
+
+    const store = useTransferStore()
+    const result = await store.createTransfer({
+      racunPosiljaocaId: 10,
+      racunPrimaocaId: 20,
+      iznos: 1000,
+      svrha: 'Test',
+    })
+
+    expect(result).toEqual(mockTransfers[0])
+  })
+
+  it('sets loading true during fetch and false after', async () => {
+    let resolve!: (v: any) => void
+    vi.mocked(transferApi.listByClient).mockReturnValueOnce(
+      new Promise(r => { resolve = r })
+    )
+
+    const store = useTransferStore()
+    const promise = store.fetchByClient('5')
+    expect(store.loading).toBe(true)
+
+    resolve({ data: { transfers: [], total: 0 } })
+    await promise
+    expect(store.loading).toBe(false)
+  })
+
+  it('clearError resets error', async () => {
+    vi.mocked(transferApi.listByClient).mockRejectedValueOnce({
+      response: { data: { message: 'Error!' } },
+    })
+
+    const store = useTransferStore()
+    await store.fetchByClient('5')
+    expect(store.error).toBe('Error!')
+
+    store.clearError()
+    expect(store.error).toBe('')
+  })
+})

--- a/src/__tests__/views/ClientTransfersView.test.ts
+++ b/src/__tests__/views/ClientTransfersView.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import ClientTransfersView from '../../views/client/ClientTransfersView.vue'
+import { useClientAuthStore } from '../../stores/clientAuth'
+import { useClientAccountStore } from '../../stores/clientAccount'
+
+vi.mock('vue-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('vue-router')>()
+  return {
+    ...actual,
+    useRoute: () => ({ query: {} }),
+    useRouter: () => ({ push: vi.fn() }),
+  }
+})
+
+vi.mock('../../api/transfer', () => ({
+  transferApi: {
+    create: vi.fn(),
+    listByClient: vi.fn(),
+    listByAccount: vi.fn(),
+    calculateExchange: vi.fn(),
+  },
+}))
+
+vi.mock('../../api/clientAccount', () => ({
+  clientAccountApi: { listByClient: vi.fn(), get: vi.fn() },
+}))
+
+vi.mock('../../api/clientAuth', () => ({
+  clientAuthApi: { login: vi.fn() },
+  default: { get: vi.fn(), post: vi.fn(), interceptors: { request: { use: vi.fn() } } },
+}))
+
+import { transferApi } from '../../api/transfer'
+import { clientAccountApi } from '../../api/clientAccount'
+
+const mockAccounts = [
+  {
+    id: '1', brojRacuna: '111111111111111111', clientId: '5', firmaId: '0',
+    currencyId: '1', currencyKod: 'RSD', tip: 'tekuci', vrsta: 'licni',
+    stanje: 50000, raspolozivoStanje: 50000, dnevniLimit: 100000, mesecniLimit: 1000000,
+    naziv: 'RSD Account', status: 'aktivan',
+  },
+  {
+    id: '2', brojRacuna: '222222222222222222', clientId: '5', firmaId: '0',
+    currencyId: '2', currencyKod: 'EUR', tip: 'devizni', vrsta: 'licni',
+    stanje: 500, raspolozivoStanje: 450, dnevniLimit: 10000, mesecniLimit: 100000,
+    naziv: 'EUR Account', status: 'aktivan',
+  },
+]
+
+const mockTransfers = [
+  {
+    id: '1',
+    racunPosiljaocaId: '1',
+    racunPrimaocaId: '2',
+    iznos: 1000,
+    valutaIznosa: 'RSD',
+    konvertovaniIznos: 1000,
+    kurs: 1,
+    svrha: 'Kirija',
+    status: 'uspesno',
+    vremeTransakcije: '2026-03-01T10:00:00Z',
+  },
+]
+
+describe('ClientTransfersView', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+
+    const authStore = useClientAuthStore()
+    authStore.accessToken = 'test-token'
+    authStore.client = { id: '5', ime: 'Ana', prezime: 'Jović', email: 'ana@gmail.com', permissions: ['client.basic'] }
+
+    vi.mocked(clientAccountApi.listByClient).mockResolvedValue({
+      data: { accounts: mockAccounts },
+    })
+
+    vi.mocked(transferApi.listByClient).mockResolvedValue({
+      data: { transfers: mockTransfers, total: 1 },
+    })
+  })
+
+  it('renders Novi transfer heading', async () => {
+    const wrapper = mount(ClientTransfersView)
+    await flushPromises()
+    expect(wrapper.text()).toContain('Novi transfer')
+  })
+
+  it('loads accounts and transfers on mount', async () => {
+    mount(ClientTransfersView)
+    await flushPromises()
+    expect(clientAccountApi.listByClient).toHaveBeenCalledWith('5')
+    expect(transferApi.listByClient).toHaveBeenCalledWith('5', expect.any(Object))
+  })
+
+  it('populates source account dropdown', async () => {
+    const wrapper = mount(ClientTransfersView)
+    await flushPromises()
+    const selects = wrapper.findAll('select')
+    expect(selects.length).toBeGreaterThanOrEqual(1)
+    expect(selects[0].text()).toContain('RSD Account')
+    expect(selects[0].text()).toContain('EUR Account')
+  })
+
+  it('shows transfer history with transfers', async () => {
+    const wrapper = mount(ClientTransfersView)
+    await flushPromises()
+    expect(wrapper.text()).toContain('Kirija')
+    expect(wrapper.text()).toContain('uspesno')
+  })
+
+  it('shows empty state when no transfers', async () => {
+    vi.mocked(transferApi.listByClient).mockResolvedValueOnce({
+      data: { transfers: [], total: 0 },
+    })
+    const wrapper = mount(ClientTransfersView)
+    await flushPromises()
+    expect(wrapper.text()).toContain('Nema transfera')
+  })
+
+  it('Dalje button is disabled when form is incomplete', async () => {
+    const wrapper = mount(ClientTransfersView)
+    await flushPromises()
+    const daljeBtn = wrapper.findAll('button').find(b => b.text() === 'Dalje')
+    expect(daljeBtn).toBeDefined()
+    expect(daljeBtn!.attributes('disabled')).toBeDefined()
+  })
+
+  it('moves to confirm step when form is filled and Dalje clicked', async () => {
+    const wrapper = mount(ClientTransfersView)
+    await flushPromises()
+
+    const selects = wrapper.findAll('select')
+    await selects[0].setValue('1')
+    await selects[1].setValue('2')
+
+    const inputs = wrapper.findAll('input')
+    const iznosInput = inputs.find(i => i.attributes('type') === 'number')
+    await iznosInput!.setValue('1000')
+
+    const svrhaInput = inputs.find(i => i.attributes('placeholder') === 'Svrha transakcije')
+    await svrhaInput!.setValue('Test')
+
+    await wrapper.vm.$nextTick()
+
+    const daljeBtn = wrapper.findAll('button').find(b => b.text() === 'Dalje')
+    await daljeBtn!.trigger('click')
+
+    expect(wrapper.text()).toContain('Potvrda transfera')
+  })
+
+  it('shows success step after successful transfer', async () => {
+    vi.mocked(transferApi.create).mockResolvedValueOnce({
+      data: { transfer: mockTransfers[0] },
+    })
+
+    const wrapper = mount(ClientTransfersView)
+    await flushPromises()
+
+    const selects = wrapper.findAll('select')
+    await selects[0].setValue('1')
+    await selects[1].setValue('2')
+
+    const inputs = wrapper.findAll('input')
+    const iznosInput = inputs.find(i => i.attributes('type') === 'number')
+    await iznosInput!.setValue('1000')
+
+    const svrhaInput = inputs.find(i => i.attributes('placeholder') === 'Svrha transakcije')
+    await svrhaInput!.setValue('Test')
+
+    await wrapper.vm.$nextTick()
+    const daljeBtn = wrapper.findAll('button').find(b => b.text() === 'Dalje')
+    await daljeBtn!.trigger('click')
+
+    const potvrdiBtn = wrapper.findAll('button').find(b => b.text().includes('Potvrdi'))
+    await potvrdiBtn!.trigger('click')
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('uspešno realizovan')
+  })
+})

--- a/src/api/transfer.ts
+++ b/src/api/transfer.ts
@@ -1,0 +1,74 @@
+import clientApi from './clientAuth'
+
+export interface TransferItem {
+  id: string
+  racunPosiljaocaId: string
+  racunPrimaocaId: string
+  iznos: number
+  valutaIznosa: string
+  konvertovaniIznos: number
+  kurs: number
+  svrha: string
+  status: string
+  vremeTransakcije: string
+}
+
+export interface CreateTransferPayload {
+  racunPosiljaocaId: number
+  racunPrimaocaId: number
+  iznos: number
+  svrha: string
+}
+
+export interface TransferFilter {
+  dateFrom?: string
+  dateTo?: string
+  minAmount?: number
+  maxAmount?: number
+  status?: string
+  page?: number
+  pageSize?: number
+}
+
+export const transferApi = {
+  create: (data: CreateTransferPayload) =>
+    clientApi.post('/transfers', {
+      racun_posiljaoca_id: data.racunPosiljaocaId,
+      racun_primaoca_id:   data.racunPrimaocaId,
+      iznos:               data.iznos,
+      svrha:               data.svrha,
+    }),
+
+  listByClient: (clientId: string, filter: TransferFilter = {}) =>
+    clientApi.get(`/transfers/client/${clientId}`, {
+      params: {
+        date_from:  filter.dateFrom,
+        date_to:    filter.dateTo,
+        min_amount: filter.minAmount,
+        max_amount: filter.maxAmount,
+        status:     filter.status,
+        page:       filter.page,
+        page_size:  filter.pageSize,
+      },
+    }),
+
+  listByAccount: (accountId: string, filter: TransferFilter = {}) =>
+    clientApi.get(`/transfers/account/${accountId}`, {
+      params: {
+        date_from:  filter.dateFrom,
+        date_to:    filter.dateTo,
+        min_amount: filter.minAmount,
+        max_amount: filter.maxAmount,
+        status:     filter.status,
+        page:       filter.page,
+        page_size:  filter.pageSize,
+      },
+    }),
+
+  calculateExchange: (fromCurrency: string, toCurrency: string, amount: number) =>
+    clientApi.post('/exchange/calculate', {
+      from_currency: fromCurrency,
+      to_currency:   toCurrency,
+      amount,
+    }),
+}

--- a/src/stores/transfer.ts
+++ b/src/stores/transfer.ts
@@ -1,0 +1,51 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import { transferApi, type TransferItem, type CreateTransferPayload, type TransferFilter } from '../api/transfer'
+
+export const useTransferStore = defineStore('transfer', () => {
+  const transfers = ref<TransferItem[]>([])
+  const total = ref(0)
+  const page = ref(1)
+  const pageSize = 20
+  const loading = ref(false)
+  const error = ref('')
+
+  async function createTransfer(data: CreateTransferPayload): Promise<TransferItem> {
+    const res = await transferApi.create(data)
+    return res.data.transfer
+  }
+
+  async function fetchByClient(clientId: string, filter: TransferFilter = {}) {
+    loading.value = true
+    error.value = ''
+    try {
+      const res = await transferApi.listByClient(clientId, { ...filter, page: page.value, pageSize })
+      transfers.value = res.data.transfers ?? []
+      total.value = Number(res.data.total ?? 0)
+    } catch (e: any) {
+      error.value = e.response?.data?.message || 'Failed to load transfers.'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function fetchByAccount(accountId: string, filter: TransferFilter = {}) {
+    loading.value = true
+    error.value = ''
+    try {
+      const res = await transferApi.listByAccount(accountId, { ...filter, page: page.value, pageSize })
+      transfers.value = res.data.transfers ?? []
+      total.value = Number(res.data.total ?? 0)
+    } catch (e: any) {
+      error.value = e.response?.data?.message || 'Failed to load transfers.'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  function clearError() {
+    error.value = ''
+  }
+
+  return { transfers, total, page, pageSize, loading, error, createTransfer, fetchByClient, fetchByAccount, clearError }
+})

--- a/src/views/client/ClientTransfersView.vue
+++ b/src/views/client/ClientTransfersView.vue
@@ -1,9 +1,323 @@
 <script setup lang="ts">
+import { ref, computed, watch, onMounted } from 'vue'
+import { useRoute } from 'vue-router'
+import { useClientAccountStore } from '../../stores/clientAccount'
+import { useTransferStore } from '../../stores/transfer'
+import { useClientAuthStore } from '../../stores/clientAuth'
+import { transferApi } from '../../api/transfer'
+
+const route = useRoute()
+const clientAuthStore = useClientAuthStore()
+const accountStore = useClientAccountStore()
+const transferStore = useTransferStore()
+
+const step = ref<'form' | 'confirm' | 'success'>('form')
+
+const form = ref({
+  fromAccountId: (route.query.fromAccountId as string) || '',
+  toAccountId: '',
+  iznos: '',
+  svrha: '',
+})
+
+const lastCreated = ref<any>(null)
+const exchangePreview = ref<{ outputAmount: number; rate: number } | null>(null)
+const loadingPreview = ref(false)
+
+const clientId = computed(() => String(clientAuthStore.client?.id ?? ''))
+
+const fromAccount = computed(() =>
+  accountStore.accounts.find(a => String(a.id) === form.value.fromAccountId) ?? null
+)
+const toAccount = computed(() =>
+  accountStore.accounts.find(a => String(a.id) === form.value.toAccountId) ?? null
+)
+
+const isCrossCurrency = computed(() =>
+  !!fromAccount.value && !!toAccount.value &&
+  fromAccount.value.currencyKod !== toAccount.value.currencyKod
+)
+
+async function fetchExchangePreview() {
+  if (!isCrossCurrency.value || !form.value.iznos || Number(form.value.iznos) <= 0) {
+    exchangePreview.value = null
+    return
+  }
+  loadingPreview.value = true
+  try {
+    const res = await transferApi.calculateExchange(
+      fromAccount.value!.currencyKod,
+      toAccount.value!.currencyKod,
+      Number(form.value.iznos),
+    )
+    exchangePreview.value = {
+      outputAmount: res.data.converted_amount ?? res.data.output_amount ?? 0,
+      rate: res.data.rate ?? 0,
+    }
+  } catch {
+    exchangePreview.value = null
+  } finally {
+    loadingPreview.value = false
+  }
+}
+
+watch(
+  () => [form.value.fromAccountId, form.value.toAccountId, form.value.iznos],
+  fetchExchangePreview,
+)
+
+function goToConfirm() {
+  if (!form.value.fromAccountId || !form.value.toAccountId || !form.value.iznos || !form.value.svrha) return
+  if (form.value.fromAccountId === form.value.toAccountId) return
+  if (Number(form.value.iznos) <= 0) return
+  step.value = 'confirm'
+}
+
+async function handleSubmit() {
+  try {
+    const result = await transferStore.createTransfer({
+      racunPosiljaocaId: Number(form.value.fromAccountId),
+      racunPrimaocaId: Number(form.value.toAccountId),
+      iznos: Number(form.value.iznos),
+      svrha: form.value.svrha,
+    })
+    lastCreated.value = result
+    step.value = 'success'
+    // refresh history
+    await transferStore.fetchByClient(clientId.value)
+  } catch {
+    step.value = 'form'
+  }
+}
+
+function startNew() {
+  form.value = { fromAccountId: '', toAccountId: '', iznos: '', svrha: '' }
+  exchangePreview.value = null
+  step.value = 'form'
+}
+
+// History filters
+const historyFilter = ref({ status: '', dateFrom: '', dateTo: '' })
+
+async function applyHistoryFilter() {
+  transferStore.page = 1
+  await transferStore.fetchByClient(clientId.value, {
+    status: historyFilter.value.status || undefined,
+    dateFrom: historyFilter.value.dateFrom || undefined,
+    dateTo: historyFilter.value.dateTo || undefined,
+  })
+}
+
+async function prevPage() {
+  if (transferStore.page > 1) {
+    transferStore.page--
+    await transferStore.fetchByClient(clientId.value, {
+      status: historyFilter.value.status || undefined,
+      dateFrom: historyFilter.value.dateFrom || undefined,
+      dateTo: historyFilter.value.dateTo || undefined,
+    })
+  }
+}
+
+async function nextPage() {
+  if (transferStore.page * transferStore.pageSize < transferStore.total) {
+    transferStore.page++
+    await transferStore.fetchByClient(clientId.value, {
+      status: historyFilter.value.status || undefined,
+      dateFrom: historyFilter.value.dateFrom || undefined,
+      dateTo: historyFilter.value.dateTo || undefined,
+    })
+  }
+}
+
+const totalPages = computed(() =>
+  Math.ceil(transferStore.total / transferStore.pageSize) || 1
+)
+
+function statusBadgeClass(status: string) {
+  switch (status) {
+    case 'uspesno': return 'badge-success'
+    case 'neuspesno': return 'badge-error'
+    case 'u_obradi': return 'badge-warning'
+    default: return 'badge-neutral'
+  }
+}
+
+onMounted(async () => {
+  if (clientId.value) {
+    await accountStore.fetchAccounts(clientId.value)
+    await transferStore.fetchByClient(clientId.value)
+  }
+})
 </script>
 
 <template>
   <div class="page-container">
-    <h1>ClientTransfersView</h1>
-    <p>Coming soon</p>
+    <h1 class="page-title">Transferi</h1>
+
+    <!-- New Transfer Card -->
+    <div class="card mb-6">
+      <div class="card-header">
+        <h2>Novi transfer</h2>
+      </div>
+      <div class="card-body">
+
+        <!-- Step: Form -->
+        <div v-if="step === 'form'">
+          <div class="form-group">
+            <label>Sa računa</label>
+            <select v-model="form.fromAccountId" class="form-input">
+              <option value="">-- Izaberite račun --</option>
+              <option v-for="acc in accountStore.accounts" :key="acc.id" :value="String(acc.id)">
+                {{ acc.naziv || acc.brojRacuna }} ({{ acc.currencyKod }}) — {{ acc.raspolozivoStanje.toLocaleString('sr-RS') }}
+              </option>
+            </select>
+          </div>
+
+          <div class="form-group">
+            <label>Na račun</label>
+            <select v-model="form.toAccountId" class="form-input">
+              <option value="">-- Izaberite račun --</option>
+              <option
+                v-for="acc in accountStore.accounts"
+                :key="acc.id"
+                :value="String(acc.id)"
+                :disabled="String(acc.id) === form.fromAccountId"
+              >
+                {{ acc.naziv || acc.brojRacuna }} ({{ acc.currencyKod }})
+              </option>
+            </select>
+          </div>
+
+          <div class="form-group">
+            <label>Iznos</label>
+            <input v-model="form.iznos" type="number" min="0.01" step="0.01" class="form-input" placeholder="0.00" />
+          </div>
+
+          <!-- Cross-currency preview -->
+          <div v-if="isCrossCurrency" class="exchange-preview">
+            <span v-if="loadingPreview" class="text-muted">Računam kurs...</span>
+            <span v-else-if="exchangePreview">
+              {{ Number(form.iznos).toLocaleString('sr-RS') }} {{ fromAccount?.currencyKod }}
+              ≈ {{ exchangePreview.outputAmount.toLocaleString('sr-RS') }} {{ toAccount?.currencyKod }}
+              (kurs: {{ exchangePreview.rate }})
+            </span>
+          </div>
+
+          <div class="form-group">
+            <label>Svrha</label>
+            <input v-model="form.svrha" type="text" class="form-input" placeholder="Svrha transakcije" />
+          </div>
+
+          <div v-if="transferStore.error" class="error-message">{{ transferStore.error }}</div>
+
+          <button
+            class="btn btn-primary"
+            :disabled="!form.fromAccountId || !form.toAccountId || !form.iznos || !form.svrha || form.fromAccountId === form.toAccountId"
+            @click="goToConfirm"
+          >
+            Dalje
+          </button>
+        </div>
+
+        <!-- Step: Confirm -->
+        <div v-else-if="step === 'confirm'">
+          <h3>Potvrda transfera</h3>
+          <table class="detail-table">
+            <tbody>
+              <tr>
+                <th>Sa računa</th>
+                <td>{{ fromAccount?.naziv || fromAccount?.brojRacuna }} ({{ fromAccount?.currencyKod }})</td>
+              </tr>
+              <tr>
+                <th>Na račun</th>
+                <td>{{ toAccount?.naziv || toAccount?.brojRacuna }} ({{ toAccount?.currencyKod }})</td>
+              </tr>
+              <tr>
+                <th>Iznos</th>
+                <td>{{ Number(form.iznos).toLocaleString('sr-RS') }} {{ fromAccount?.currencyKod }}</td>
+              </tr>
+              <tr v-if="exchangePreview">
+                <th>Konvertovani iznos</th>
+                <td>{{ exchangePreview.outputAmount.toLocaleString('sr-RS') }} {{ toAccount?.currencyKod }}</td>
+              </tr>
+              <tr>
+                <th>Svrha</th>
+                <td>{{ form.svrha }}</td>
+              </tr>
+            </tbody>
+          </table>
+
+          <div class="action-row">
+            <button class="btn btn-secondary" @click="step = 'form'">Nazad</button>
+            <button class="btn btn-primary" :disabled="transferStore.loading" @click="handleSubmit">
+              {{ transferStore.loading ? 'Šaljem...' : 'Potvrdi' }}
+            </button>
+          </div>
+        </div>
+
+        <!-- Step: Success -->
+        <div v-else-if="step === 'success'" class="success-box">
+          <div class="success-icon">✓</div>
+          <p>Transfer je uspešno realizovan!</p>
+          <button class="btn btn-primary" @click="startNew">Novi transfer</button>
+        </div>
+
+      </div>
+    </div>
+
+    <!-- Transfer History -->
+    <div class="card">
+      <div class="card-header">
+        <h2>Istorija transfera</h2>
+      </div>
+      <div class="card-body">
+
+        <!-- Filters -->
+        <div class="filter-row">
+          <select v-model="historyFilter.status" class="form-input filter-input" @change="applyHistoryFilter">
+            <option value="">Svi statusi</option>
+            <option value="uspesno">Uspešno</option>
+            <option value="neuspesno">Neuspešno</option>
+            <option value="u_obradi">U obradi</option>
+          </select>
+          <input v-model="historyFilter.dateFrom" type="date" class="form-input filter-input" @change="applyHistoryFilter" />
+          <input v-model="historyFilter.dateTo" type="date" class="form-input filter-input" @change="applyHistoryFilter" />
+        </div>
+
+        <div v-if="transferStore.loading" class="loading-msg">Učitavam...</div>
+        <div v-else-if="transferStore.transfers.length === 0" class="empty-msg">Nema transfera.</div>
+        <table v-else class="data-table">
+          <thead>
+            <tr>
+              <th>Datum</th>
+              <th>Sa računa</th>
+              <th>Na račun</th>
+              <th>Iznos</th>
+              <th>Svrha</th>
+              <th>Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="t in transferStore.transfers" :key="t.id">
+              <td>{{ new Date(t.vremeTransakcije).toLocaleDateString('sr-RS') }}</td>
+              <td>{{ t.racunPosiljaocaId }}</td>
+              <td>{{ t.racunPrimaocaId }}</td>
+              <td>{{ t.iznos.toLocaleString('sr-RS') }} {{ t.valutaIznosa }}</td>
+              <td>{{ t.svrha }}</td>
+              <td><span :class="['badge', statusBadgeClass(t.status)]">{{ t.status }}</span></td>
+            </tr>
+          </tbody>
+        </table>
+
+        <!-- Pagination -->
+        <div v-if="transferStore.total > transferStore.pageSize" class="pagination">
+          <button class="btn btn-secondary" :disabled="transferStore.page <= 1" @click="prevPage">‹</button>
+          <span>{{ transferStore.page }} / {{ totalPages }}</span>
+          <button class="btn btn-secondary" :disabled="transferStore.page >= totalPages" @click="nextPage">›</button>
+        </div>
+
+      </div>
+    </div>
   </div>
 </template>


### PR DESCRIPTION
Implements Issue #15 (TRANSFER-FE-5):

- transferApi (create, listByClient, listByAccount, calculateExchange)
- useTransferStore (Pinia store with fetchByClient, fetchByAccount, createTransfer)
- ClientTransfersView: 3-step flow (form → confirm → success), cross-currency rate preview, transfer history with status/date filters and pagination
- Unit tests: 8 store tests + 8 view tests, all 89 tests passing

Fixes #15