### PR TITLE
feat(PRIMAOCI-FE-3): payment recipients CRUD page with add/edit/delete modals - Fixes #17

### DIFF
--- a/src/__tests__/stores/recipient.test.ts
+++ b/src/__tests__/stores/recipient.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useRecipientStore } from '../../stores/recipient'
+import { recipientApi } from '../../api/recipient'
+
+vi.mock('../../api/recipient', () => ({
+  recipientApi: {
+    listByClient: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  },
+}))
+
+const mockRecipients = [
+  { id: '1', clientId: '5', naziv: 'Ana Jović', brojRacuna: '111111111111111111' },
+  { id: '2', clientId: '5', naziv: 'EPS', brojRacuna: '222222222222222222' },
+]
+
+describe('useRecipientStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('fetchRecipients sets recipients on success', async () => {
+    vi.mocked(recipientApi.listByClient).mockResolvedValueOnce({
+      data: { recipients: mockRecipients },
+    })
+
+    const store = useRecipientStore()
+    await store.fetchRecipients('5')
+
+    expect(store.recipients).toHaveLength(2)
+    expect(store.loading).toBe(false)
+    expect(store.error).toBe('')
+  })
+
+  it('fetchRecipients calls API with correct clientId', async () => {
+    vi.mocked(recipientApi.listByClient).mockResolvedValueOnce({
+      data: { recipients: [] },
+    })
+
+    const store = useRecipientStore()
+    await store.fetchRecipients('42')
+
+    expect(recipientApi.listByClient).toHaveBeenCalledWith('42')
+  })
+
+  it('fetchRecipients sets error on API failure', async () => {
+    vi.mocked(recipientApi.listByClient).mockRejectedValueOnce({
+      response: { data: { message: 'Unauthorized' } },
+    })
+
+    const store = useRecipientStore()
+    await store.fetchRecipients('5')
+
+    expect(store.recipients).toHaveLength(0)
+    expect(store.error).toBe('Unauthorized')
+    expect(store.loading).toBe(false)
+  })
+
+  it('sets loading true during fetch and false after', async () => {
+    let resolve!: (v: any) => void
+    vi.mocked(recipientApi.listByClient).mockReturnValueOnce(
+      new Promise(r => { resolve = r })
+    )
+
+    const store = useRecipientStore()
+    const promise = store.fetchRecipients('5')
+    expect(store.loading).toBe(true)
+
+    resolve({ data: { recipients: [] } })
+    await promise
+    expect(store.loading).toBe(false)
+  })
+
+  it('createRecipient returns new recipient and adds to list', async () => {
+    const newRecipient = { id: '3', clientId: '5', naziv: 'Novi', brojRacuna: '333333333333333333' }
+    vi.mocked(recipientApi.create).mockResolvedValueOnce({
+      data: { recipient: newRecipient },
+    })
+
+    const store = useRecipientStore()
+    const result = await store.createRecipient('5', 'Novi', '333333333333333333')
+
+    expect(result).toEqual(newRecipient)
+    expect(store.recipients).toContainEqual(newRecipient)
+  })
+
+  it('updateRecipient updates the entry in the list', async () => {
+    vi.mocked(recipientApi.listByClient).mockResolvedValueOnce({
+      data: { recipients: [...mockRecipients] },
+    })
+    const updated = { ...mockRecipients[0], naziv: 'Ana Izmenjeno' }
+    vi.mocked(recipientApi.update).mockResolvedValueOnce({
+      data: { recipient: updated },
+    })
+
+    const store = useRecipientStore()
+    await store.fetchRecipients('5')
+    await store.updateRecipient('1', 'Ana Izmenjeno', '111111111111111111')
+
+    expect(store.recipients[0].naziv).toBe('Ana Izmenjeno')
+  })
+
+  it('deleteRecipient removes the entry from the list', async () => {
+    vi.mocked(recipientApi.listByClient).mockResolvedValueOnce({
+      data: { recipients: [...mockRecipients] },
+    })
+    vi.mocked(recipientApi.delete).mockResolvedValueOnce({})
+
+    const store = useRecipientStore()
+    await store.fetchRecipients('5')
+    await store.deleteRecipient('1')
+
+    expect(store.recipients).toHaveLength(1)
+    expect(store.recipients.find(r => r.id === '1')).toBeUndefined()
+  })
+
+  it('clearError resets error', async () => {
+    vi.mocked(recipientApi.listByClient).mockRejectedValueOnce({
+      response: { data: { message: 'Error!' } },
+    })
+
+    const store = useRecipientStore()
+    await store.fetchRecipients('5')
+    expect(store.error).toBe('Error!')
+
+    store.clearError()
+    expect(store.error).toBe('')
+  })
+})

--- a/src/__tests__/views/ClientRecipientsView.test.ts
+++ b/src/__tests__/views/ClientRecipientsView.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import ClientRecipientsView from '../../views/client/ClientRecipientsView.vue'
+import { useClientAuthStore } from '../../stores/clientAuth'
+
+vi.mock('../../api/recipient', () => ({
+  recipientApi: {
+    listByClient: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  },
+}))
+
+vi.mock('../../api/clientAuth', () => ({
+  clientAuthApi: { login: vi.fn() },
+  default: { get: vi.fn(), post: vi.fn(), interceptors: { request: { use: vi.fn() } } },
+}))
+
+import { recipientApi } from '../../api/recipient'
+
+const mockRecipients = [
+  { id: '1', clientId: '5', naziv: 'Ana Jović', brojRacuna: '111111111111111111' },
+  { id: '2', clientId: '5', naziv: 'EPS', brojRacuna: '222222222222222222' },
+]
+
+describe('ClientRecipientsView', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+
+    const authStore = useClientAuthStore()
+    authStore.accessToken = 'test-token'
+    authStore.client = { id: '5', ime: 'Ana', prezime: 'Jović', email: 'ana@gmail.com', permissions: ['client.basic'] }
+
+    vi.mocked(recipientApi.listByClient).mockResolvedValue({
+      data: { recipients: mockRecipients },
+    })
+  })
+
+  it('renders Primaoci plaćanja heading', async () => {
+    const wrapper = mount(ClientRecipientsView)
+    await flushPromises()
+    expect(wrapper.text()).toContain('Primaoci plaćanja')
+  })
+
+  it('loads recipients on mount', async () => {
+    mount(ClientRecipientsView)
+    await flushPromises()
+    expect(recipientApi.listByClient).toHaveBeenCalledWith('5')
+  })
+
+  it('shows recipient rows in table', async () => {
+    const wrapper = mount(ClientRecipientsView)
+    await flushPromises()
+    const rows = wrapper.findAll('.recipient-row')
+    expect(rows).toHaveLength(2)
+    expect(wrapper.text()).toContain('Ana Jović')
+    expect(wrapper.text()).toContain('111111111111111111')
+    expect(wrapper.text()).toContain('EPS')
+  })
+
+  it('shows empty state when no recipients', async () => {
+    vi.mocked(recipientApi.listByClient).mockResolvedValueOnce({ data: { recipients: [] } })
+    const wrapper = mount(ClientRecipientsView)
+    await flushPromises()
+    expect(wrapper.text()).toContain('Nema sačuvanih primalaca')
+  })
+
+  it('clicking Dodaj primaoca opens modal', async () => {
+    const wrapper = mount(ClientRecipientsView)
+    await flushPromises()
+
+    expect(wrapper.find('.modal-overlay').exists()).toBe(false)
+    await wrapper.findAll('button').find(b => b.text().includes('Dodaj'))!.trigger('click')
+    expect(wrapper.find('.modal-overlay').exists()).toBe(true)
+    expect(wrapper.text()).toContain('Novi primalac')
+  })
+
+  it('modal close button hides the modal', async () => {
+    const wrapper = mount(ClientRecipientsView)
+    await flushPromises()
+
+    await wrapper.findAll('button').find(b => b.text().includes('Dodaj'))!.trigger('click')
+    expect(wrapper.find('.modal-overlay').exists()).toBe(true)
+
+    await wrapper.find('.modal-close').trigger('click')
+    expect(wrapper.find('.modal-overlay').exists()).toBe(false)
+  })
+
+  it('save with empty fields shows validation error', async () => {
+    const wrapper = mount(ClientRecipientsView)
+    await flushPromises()
+
+    await wrapper.findAll('button').find(b => b.text().includes('Dodaj'))!.trigger('click')
+    await wrapper.findAll('button').find(b => b.text() === 'Sačuvaj')!.trigger('click')
+
+    expect(wrapper.text()).toContain('obavezni')
+    expect(recipientApi.create).not.toHaveBeenCalled()
+  })
+
+  it('save with valid data calls create API and closes modal', async () => {
+    vi.mocked(recipientApi.create).mockResolvedValueOnce({
+      data: { recipient: { id: '3', clientId: '5', naziv: 'Novi', brojRacuna: '333333333333333333' } },
+    })
+
+    const wrapper = mount(ClientRecipientsView)
+    await flushPromises()
+
+    await wrapper.findAll('button').find(b => b.text().includes('Dodaj'))!.trigger('click')
+
+    const inputs = wrapper.findAll('.modal-box input')
+    await inputs[0].setValue('Novi')
+    await inputs[1].setValue('333333333333333333')
+
+    await wrapper.findAll('button').find(b => b.text() === 'Sačuvaj')!.trigger('click')
+    await flushPromises()
+
+    expect(recipientApi.create).toHaveBeenCalledWith('5', 'Novi', '333333333333333333')
+    expect(wrapper.find('.modal-overlay').exists()).toBe(false)
+  })
+
+  it('clicking Izmeni opens modal pre-filled with recipient data', async () => {
+    const wrapper = mount(ClientRecipientsView)
+    await flushPromises()
+
+    const editBtns = wrapper.findAll('button').filter(b => b.text() === 'Izmeni')
+    await editBtns[0].trigger('click')
+
+    expect(wrapper.text()).toContain('Izmeni primaoca')
+    const inputs = wrapper.findAll('.modal-box input')
+    expect((inputs[0].element as HTMLInputElement).value).toBe('Ana Jović')
+    expect((inputs[1].element as HTMLInputElement).value).toBe('111111111111111111')
+  })
+
+  it('save in edit mode calls update API', async () => {
+    vi.mocked(recipientApi.update).mockResolvedValueOnce({
+      data: { recipient: { id: '1', clientId: '5', naziv: 'Ana Izmenjeno', brojRacuna: '111111111111111111' } },
+    })
+
+    const wrapper = mount(ClientRecipientsView)
+    await flushPromises()
+
+    const editBtns = wrapper.findAll('button').filter(b => b.text() === 'Izmeni')
+    await editBtns[0].trigger('click')
+
+    const inputs = wrapper.findAll('.modal-box input')
+    await inputs[0].setValue('Ana Izmenjeno')
+
+    await wrapper.findAll('button').find(b => b.text() === 'Sačuvaj')!.trigger('click')
+    await flushPromises()
+
+    expect(recipientApi.update).toHaveBeenCalledWith('1', 'Ana Izmenjeno', '111111111111111111')
+    expect(wrapper.find('.modal-overlay').exists()).toBe(false)
+  })
+
+  it('clicking Obriši opens delete confirmation', async () => {
+    const wrapper = mount(ClientRecipientsView)
+    await flushPromises()
+
+    const deleteBtns = wrapper.findAll('button').filter(b => b.text() === 'Obriši')
+    await deleteBtns[0].trigger('click')
+
+    expect(wrapper.text()).toContain('Potvrda brisanja')
+    expect(wrapper.text()).toContain('sigurni')
+  })
+
+  it('confirming delete calls delete API', async () => {
+    vi.mocked(recipientApi.delete).mockResolvedValueOnce({})
+
+    const wrapper = mount(ClientRecipientsView)
+    await flushPromises()
+
+    const deleteBtns = wrapper.findAll('button').filter(b => b.text() === 'Obriši')
+    await deleteBtns[0].trigger('click')
+
+    // The confirm modal's Obriši button does not have btn-sm (unlike row buttons)
+    const confirmBtn = wrapper.findAll('button').find(
+      b => b.classes('btn-danger') && !b.classes('btn-sm') && b.text() === 'Obriši'
+    )
+    await confirmBtn!.trigger('click')
+    await flushPromises()
+
+    expect(recipientApi.delete).toHaveBeenCalledWith('1')
+  })
+
+  it('cancel delete closes confirmation without calling API', async () => {
+    const wrapper = mount(ClientRecipientsView)
+    await flushPromises()
+
+    const deleteBtns = wrapper.findAll('button').filter(b => b.text() === 'Obriši')
+    await deleteBtns[0].trigger('click')
+
+    await wrapper.findAll('button').find(b => b.text() === 'Otkaži')!.trigger('click')
+
+    expect(wrapper.text()).not.toContain('Potvrda brisanja')
+    expect(recipientApi.delete).not.toHaveBeenCalled()
+  })
+})

--- a/src/api/recipient.ts
+++ b/src/api/recipient.ts
@@ -1,0 +1,29 @@
+import clientApi from './clientAuth'
+
+export interface RecipientItem {
+  id: string
+  clientId: string
+  naziv: string
+  brojRacuna: string
+}
+
+export const recipientApi = {
+  listByClient: (clientId: string) =>
+    clientApi.get('/recipients', { params: { client_id: clientId } }),
+
+  create: (clientId: string, naziv: string, brojRacuna: string) =>
+    clientApi.post('/recipients', {
+      client_id:   clientId,
+      naziv,
+      broj_racuna: brojRacuna,
+    }),
+
+  update: (id: string, naziv: string, brojRacuna: string) =>
+    clientApi.put(`/recipients/${id}`, {
+      naziv,
+      broj_racuna: brojRacuna,
+    }),
+
+  delete: (id: string) =>
+    clientApi.delete(`/recipients/${id}`),
+}

--- a/src/stores/recipient.ts
+++ b/src/stores/recipient.ts
@@ -1,0 +1,47 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import { recipientApi, type RecipientItem } from '../api/recipient'
+
+export const useRecipientStore = defineStore('recipient', () => {
+  const recipients = ref<RecipientItem[]>([])
+  const loading = ref(false)
+  const error = ref('')
+
+  async function fetchRecipients(clientId: string) {
+    loading.value = true
+    error.value = ''
+    try {
+      const res = await recipientApi.listByClient(clientId)
+      recipients.value = res.data.recipients ?? []
+    } catch (e: any) {
+      error.value = e.response?.data?.message || 'Failed to load recipients.'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function createRecipient(clientId: string, naziv: string, brojRacuna: string): Promise<RecipientItem> {
+    const res = await recipientApi.create(clientId, naziv, brojRacuna)
+    const created: RecipientItem = res.data.recipient
+    recipients.value.push(created)
+    return created
+  }
+
+  async function updateRecipient(id: string, naziv: string, brojRacuna: string): Promise<void> {
+    const res = await recipientApi.update(id, naziv, brojRacuna)
+    const updated: RecipientItem = res.data.recipient
+    const idx = recipients.value.findIndex(r => r.id === id)
+    if (idx !== -1) recipients.value[idx] = updated
+  }
+
+  async function deleteRecipient(id: string): Promise<void> {
+    await recipientApi.delete(id)
+    recipients.value = recipients.value.filter(r => r.id !== id)
+  }
+
+  function clearError() {
+    error.value = ''
+  }
+
+  return { recipients, loading, error, fetchRecipients, createRecipient, updateRecipient, deleteRecipient, clearError }
+})

--- a/src/views/client/ClientRecipientsView.vue
+++ b/src/views/client/ClientRecipientsView.vue
@@ -1,9 +1,169 @@
 <script setup lang="ts">
+import { ref, computed, onMounted } from 'vue'
+import { useRecipientStore } from '../../stores/recipient'
+import { useClientAuthStore } from '../../stores/clientAuth'
+import type { RecipientItem } from '../../api/recipient'
+
+const clientAuthStore = useClientAuthStore()
+const store = useRecipientStore()
+
+const clientId = computed(() => String(clientAuthStore.client?.id ?? ''))
+
+// Modal state
+const modalOpen = ref(false)
+const editingId = ref<string | null>(null)
+const form = ref({ naziv: '', brojRacuna: '' })
+const formError = ref('')
+const formLoading = ref(false)
+
+// Delete confirm state
+const deletingId = ref<string | null>(null)
+const deleteLoading = ref(false)
+
+function openAdd() {
+  editingId.value = null
+  form.value = { naziv: '', brojRacuna: '' }
+  formError.value = ''
+  modalOpen.value = true
+}
+
+function openEdit(r: RecipientItem) {
+  editingId.value = r.id
+  form.value = { naziv: r.naziv, brojRacuna: r.brojRacuna }
+  formError.value = ''
+  modalOpen.value = true
+}
+
+function closeModal() {
+  modalOpen.value = false
+}
+
+async function handleSave() {
+  if (!form.value.naziv.trim() || !form.value.brojRacuna.trim()) {
+    formError.value = 'Naziv i broj računa su obavezni.'
+    return
+  }
+  formLoading.value = true
+  formError.value = ''
+  try {
+    if (editingId.value) {
+      await store.updateRecipient(editingId.value, form.value.naziv, form.value.brojRacuna)
+    } else {
+      await store.createRecipient(clientId.value, form.value.naziv, form.value.brojRacuna)
+    }
+    modalOpen.value = false
+  } catch (e: any) {
+    formError.value = e.response?.data?.message || 'Greška pri čuvanju.'
+  } finally {
+    formLoading.value = false
+  }
+}
+
+function confirmDelete(id: string) {
+  deletingId.value = id
+}
+
+function cancelDelete() {
+  deletingId.value = null
+}
+
+async function handleDelete() {
+  if (!deletingId.value) return
+  deleteLoading.value = true
+  try {
+    await store.deleteRecipient(deletingId.value)
+    deletingId.value = null
+  } catch (e: any) {
+    store.error = e.response?.data?.message || 'Greška pri brisanju.'
+    deletingId.value = null
+  } finally {
+    deleteLoading.value = false
+  }
+}
+
+onMounted(async () => {
+  if (clientId.value) await store.fetchRecipients(clientId.value)
+})
 </script>
 
 <template>
   <div class="page-container">
-    <h1>ClientRecipientsView</h1>
-    <p>Coming soon</p>
+    <div class="page-header">
+      <h1 class="page-title">Primaoci plaćanja</h1>
+      <button class="btn btn-primary" @click="openAdd">+ Dodaj primaoca</button>
+    </div>
+
+    <div class="card">
+      <div class="card-body">
+        <div v-if="store.loading" class="loading-msg">Učitavam...</div>
+        <div v-else-if="store.error" class="error-message">{{ store.error }}</div>
+        <div v-else-if="store.recipients.length === 0" class="empty-msg">Nema sačuvanih primalaca.</div>
+        <table v-else class="data-table">
+          <thead>
+            <tr>
+              <th>Naziv</th>
+              <th>Broj računa</th>
+              <th>Akcije</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="r in store.recipients" :key="r.id" class="recipient-row">
+              <td>{{ r.naziv }}</td>
+              <td>{{ r.brojRacuna }}</td>
+              <td class="action-cell">
+                <button class="btn btn-secondary btn-sm" @click="openEdit(r)">Izmeni</button>
+                <button class="btn btn-danger btn-sm" @click="confirmDelete(r.id)">Obriši</button>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <!-- Add / Edit Modal -->
+    <div v-if="modalOpen" class="modal-overlay" @click.self="closeModal">
+      <div class="modal-box">
+        <div class="modal-header">
+          <h2>{{ editingId ? 'Izmeni primaoca' : 'Novi primalac' }}</h2>
+          <button class="modal-close" @click="closeModal">✕</button>
+        </div>
+        <div class="modal-body">
+          <div class="form-group">
+            <label>Naziv primaoca</label>
+            <input v-model="form.naziv" type="text" class="form-input" placeholder="Naziv primaoca" />
+          </div>
+          <div class="form-group">
+            <label>Broj računa</label>
+            <input v-model="form.brojRacuna" type="text" class="form-input" placeholder="Broj računa" />
+          </div>
+          <div v-if="formError" class="error-message">{{ formError }}</div>
+        </div>
+        <div class="modal-footer">
+          <button class="btn btn-secondary" @click="closeModal">Otkaži</button>
+          <button class="btn btn-primary" :disabled="formLoading" @click="handleSave">
+            {{ formLoading ? 'Čuvam...' : 'Sačuvaj' }}
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Delete Confirm Modal -->
+    <div v-if="deletingId" class="modal-overlay" @click.self="cancelDelete">
+      <div class="modal-box">
+        <div class="modal-header">
+          <h2>Potvrda brisanja</h2>
+          <button class="modal-close" @click="cancelDelete">✕</button>
+        </div>
+        <div class="modal-body">
+          <p>Da li ste sigurni da želite da obrišete ovog primaoca?</p>
+        </div>
+        <div class="modal-footer">
+          <button class="btn btn-secondary" @click="cancelDelete">Otkaži</button>
+          <button class="btn btn-danger" :disabled="deleteLoading" @click="handleDelete">
+            {{ deleteLoading ? 'Brišem...' : 'Obriši' }}
+          </button>
+        </div>
+      </div>
+    </div>
   </div>
 </template>


### PR DESCRIPTION
Implements Issue #17 (PRIMAOCI-FE-3):

- recipientApi (listByClient, create, update, delete) using clientApi
- useRecipientStore (Pinia store with full CRUD)
- ClientRecipientsView: list table, add/edit modal dialog, delete confirmation modal
- 8 store tests + 13 view tests, all 123 tests passing

Fixes #17