### PR TITLE
feat(PAYMENTS-FE-1): new payment 4-step flow (form/confirm/verify/success) - Fixes #67

### DIFF
--- a/src/__tests__/stores/payment.test.ts
+++ b/src/__tests__/stores/payment.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { usePaymentStore } from '../../stores/payment'
+import { paymentApi } from '../../api/payment'
+
+vi.mock('../../api/payment', () => ({
+  paymentApi: {
+    create: vi.fn(),
+    verify: vi.fn(),
+    listByClient: vi.fn(),
+    listByAccount: vi.fn(),
+    get: vi.fn(),
+  },
+  SIFRE_PLACANJA: [],
+}))
+
+const mockPayment = {
+  id: '1',
+  racunPosiljaocaId: '10',
+  racunPrimaocaBroj: '111111111111111111',
+  iznos: 5000,
+  sifraPlacanja: '289',
+  pozivNaBroj: '97-123',
+  svrha: 'Kirija',
+  status: 'u_obradi',
+  verifikacioniKod: '123456',
+  vremeTransakcije: '2026-03-01T10:00:00Z',
+}
+
+describe('usePaymentStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('createPayment returns created payment', async () => {
+    vi.mocked(paymentApi.create).mockResolvedValueOnce({
+      data: { payment: mockPayment },
+    })
+
+    const store = usePaymentStore()
+    const result = await store.createPayment({
+      racunPosiljaocaId: 10,
+      racunPrimaocaBroj: '111111111111111111',
+      iznos: 5000,
+      sifraPlacanja: '289',
+      pozivNaBroj: '97-123',
+      svrha: 'Kirija',
+    })
+
+    expect(result).toEqual(mockPayment)
+    expect(paymentApi.create).toHaveBeenCalledOnce()
+  })
+
+  it('verifyPayment returns verified payment', async () => {
+    const verified = { ...mockPayment, status: 'uspesno' }
+    vi.mocked(paymentApi.verify).mockResolvedValueOnce({
+      data: { payment: verified },
+    })
+
+    const store = usePaymentStore()
+    const result = await store.verifyPayment('1', '123456')
+
+    expect(result.status).toBe('uspesno')
+    expect(paymentApi.verify).toHaveBeenCalledWith('1', '123456')
+  })
+
+  it('fetchByClient sets payments on success', async () => {
+    vi.mocked(paymentApi.listByClient).mockResolvedValueOnce({
+      data: { payments: [mockPayment], total: 1 },
+    })
+
+    const store = usePaymentStore()
+    await store.fetchByClient('5')
+
+    expect(store.payments).toHaveLength(1)
+    expect(store.total).toBe(1)
+    expect(store.loading).toBe(false)
+    expect(store.error).toBe('')
+  })
+
+  it('fetchByClient calls API with correct clientId and pagination', async () => {
+    vi.mocked(paymentApi.listByClient).mockResolvedValueOnce({
+      data: { payments: [], total: 0 },
+    })
+
+    const store = usePaymentStore()
+    await store.fetchByClient('42', { status: 'uspesno' })
+
+    expect(paymentApi.listByClient).toHaveBeenCalledWith('42', {
+      status: 'uspesno',
+      page: 1,
+      pageSize: 20,
+    })
+  })
+
+  it('fetchByClient sets error on API failure', async () => {
+    vi.mocked(paymentApi.listByClient).mockRejectedValueOnce({
+      response: { data: { message: 'Forbidden' } },
+    })
+
+    const store = usePaymentStore()
+    await store.fetchByClient('5')
+
+    expect(store.payments).toHaveLength(0)
+    expect(store.error).toBe('Forbidden')
+    expect(store.loading).toBe(false)
+  })
+
+  it('sets loading true during fetch and false after', async () => {
+    let resolve!: (v: any) => void
+    vi.mocked(paymentApi.listByClient).mockReturnValueOnce(
+      new Promise(r => { resolve = r })
+    )
+
+    const store = usePaymentStore()
+    const promise = store.fetchByClient('5')
+    expect(store.loading).toBe(true)
+
+    resolve({ data: { payments: [], total: 0 } })
+    await promise
+    expect(store.loading).toBe(false)
+  })
+
+  it('clearError resets error', async () => {
+    vi.mocked(paymentApi.listByClient).mockRejectedValueOnce({
+      response: { data: { message: 'Error!' } },
+    })
+
+    const store = usePaymentStore()
+    await store.fetchByClient('5')
+    expect(store.error).toBe('Error!')
+
+    store.clearError()
+    expect(store.error).toBe('')
+  })
+})

--- a/src/__tests__/views/ClientNewPaymentView.test.ts
+++ b/src/__tests__/views/ClientNewPaymentView.test.ts
@@ -1,0 +1,263 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import ClientNewPaymentView from '../../views/client/ClientNewPaymentView.vue'
+import { useClientAuthStore } from '../../stores/clientAuth'
+
+const mockPush = vi.fn()
+
+vi.mock('vue-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('vue-router')>()
+  return { ...actual, useRouter: () => ({ push: mockPush }) }
+})
+
+vi.mock('../../api/payment', () => ({
+  paymentApi: { create: vi.fn(), verify: vi.fn(), listByClient: vi.fn(), listByAccount: vi.fn(), get: vi.fn() },
+  SIFRE_PLACANJA: [
+    { sifra: '221', naziv: 'Plaćanje robe' },
+    { sifra: '289', naziv: 'Ostala plaćanja' },
+  ],
+}))
+
+vi.mock('../../api/clientAccount', () => ({
+  clientAccountApi: { listByClient: vi.fn(), get: vi.fn() },
+}))
+
+vi.mock('../../api/recipient', () => ({
+  recipientApi: { listByClient: vi.fn(), create: vi.fn(), update: vi.fn(), delete: vi.fn() },
+}))
+
+vi.mock('../../api/clientAuth', () => ({
+  clientAuthApi: { login: vi.fn() },
+  default: { get: vi.fn(), post: vi.fn(), interceptors: { request: { use: vi.fn() } } },
+}))
+
+import { paymentApi } from '../../api/payment'
+import { clientAccountApi } from '../../api/clientAccount'
+import { recipientApi } from '../../api/recipient'
+
+const mockAccounts = [
+  {
+    id: '1', brojRacuna: '111111111111111111', clientId: '5', firmaId: '0',
+    currencyId: '1', currencyKod: 'RSD', tip: 'tekuci', vrsta: 'licni',
+    stanje: 50000, raspolozivoStanje: 50000, dnevniLimit: 100000, mesecniLimit: 1000000,
+    naziv: 'RSD račun', status: 'aktivan',
+  },
+]
+
+const mockRecipients = [
+  { id: '10', clientId: '5', naziv: 'EPS', brojRacuna: '999999999999999999' },
+]
+
+const mockPayment = {
+  id: 'p1',
+  racunPosiljaocaId: '1',
+  racunPrimaocaBroj: '999999999999999999',
+  iznos: 5000,
+  sifraPlacanja: '289',
+  pozivNaBroj: '',
+  svrha: 'Struja',
+  status: 'u_obradi',
+  verifikacioniKod: '123456',
+  vremeTransakcije: '2026-03-01T10:00:00Z',
+}
+
+describe('ClientNewPaymentView', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+
+    const authStore = useClientAuthStore()
+    authStore.accessToken = 'test-token'
+    authStore.client = { id: '5', ime: 'Ana', prezime: 'Jović', email: 'ana@gmail.com', permissions: ['client.basic'] }
+
+    vi.mocked(clientAccountApi.listByClient).mockResolvedValue({ data: { accounts: mockAccounts } })
+    vi.mocked(recipientApi.listByClient).mockResolvedValue({ data: { recipients: mockRecipients } })
+  })
+
+  it('renders Novo plaćanje heading', async () => {
+    const wrapper = mount(ClientNewPaymentView)
+    await flushPromises()
+    expect(wrapper.text()).toContain('Novo plaćanje')
+  })
+
+  it('loads accounts and recipients on mount', async () => {
+    mount(ClientNewPaymentView)
+    await flushPromises()
+    expect(clientAccountApi.listByClient).toHaveBeenCalledWith('5')
+    expect(recipientApi.listByClient).toHaveBeenCalledWith('5')
+  })
+
+  it('shows account dropdown with loaded accounts', async () => {
+    const wrapper = mount(ClientNewPaymentView)
+    await flushPromises()
+    expect(wrapper.text()).toContain('RSD račun')
+  })
+
+  it('shows saved recipient dropdown by default', async () => {
+    const wrapper = mount(ClientNewPaymentView)
+    await flushPromises()
+    expect(wrapper.text()).toContain('EPS')
+    expect(wrapper.text()).toContain('Sačuvani primalac')
+  })
+
+  it('switching to manual mode shows account number input', async () => {
+    const wrapper = mount(ClientNewPaymentView)
+    await flushPromises()
+
+    const manualRadio = wrapper.find('input[value="manual"]')
+    await manualRadio.setValue(true)
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('input[placeholder="Broj računa primaoca"]').exists()).toBe(true)
+  })
+
+  it('shows šifra plaćanja dropdown', async () => {
+    const wrapper = mount(ClientNewPaymentView)
+    await flushPromises()
+    expect(wrapper.text()).toContain('Šifra plaćanja')
+    expect(wrapper.text()).toContain('289')
+  })
+
+  it('shows validation error when form incomplete and Dalje clicked', async () => {
+    const wrapper = mount(ClientNewPaymentView)
+    await flushPromises()
+
+    await wrapper.find('button.btn-primary').trigger('click')
+    expect(wrapper.text()).toContain('Izaberite izvorni račun')
+  })
+
+  it('moves to confirm step when form is filled', async () => {
+    const wrapper = mount(ClientNewPaymentView)
+    await flushPromises()
+
+    const selects = wrapper.findAll('select')
+    await selects[0].setValue('1')         // fromAccountId
+    await selects[1].setValue('10')        // savedRecipientId
+
+    const iznosInput = wrapper.find('input[type="number"]')
+    await iznosInput.setValue('5000')
+
+    const svrhaInput = wrapper.find('input[placeholder="Svrha plaćanja"]')
+    await svrhaInput.setValue('Struja')
+
+    await wrapper.find('button.btn-primary').trigger('click')
+
+    expect(wrapper.text()).toContain('Pregled plaćanja')
+    expect(wrapper.text()).toContain('999999999999999999')
+    expect(wrapper.text()).toContain('Struja')
+  })
+
+  it('Nazad from confirm returns to form', async () => {
+    const wrapper = mount(ClientNewPaymentView)
+    await flushPromises()
+
+    const selects = wrapper.findAll('select')
+    await selects[0].setValue('1')
+    await selects[1].setValue('10')
+    await wrapper.find('input[type="number"]').setValue('100')
+    await wrapper.find('input[placeholder="Svrha plaćanja"]').setValue('Test')
+    await wrapper.find('button.btn-primary').trigger('click')
+
+    expect(wrapper.text()).toContain('Pregled plaćanja')
+    await wrapper.findAll('button').find(b => b.text() === 'Nazad')!.trigger('click')
+    expect(wrapper.text()).toContain('Sa računa')
+  })
+
+  it('Potvrdi calls create API and moves to verify step', async () => {
+    vi.mocked(paymentApi.create).mockResolvedValueOnce({ data: { payment: mockPayment } })
+
+    const wrapper = mount(ClientNewPaymentView)
+    await flushPromises()
+
+    const selects = wrapper.findAll('select')
+    await selects[0].setValue('1')
+    await selects[1].setValue('10')
+    await wrapper.find('input[type="number"]').setValue('5000')
+    await wrapper.find('input[placeholder="Svrha plaćanja"]').setValue('Struja')
+    await wrapper.find('button.btn-primary').trigger('click')
+
+    await wrapper.findAll('button').find(b => b.text().includes('Potvrdi'))!.trigger('click')
+    await flushPromises()
+
+    expect(paymentApi.create).toHaveBeenCalledOnce()
+    expect(wrapper.text()).toContain('Verifikacija plaćanja')
+    expect(wrapper.text()).toContain('6-cifreni')
+  })
+
+  it('Potvrdi kod with correct code moves to success', async () => {
+    vi.mocked(paymentApi.create).mockResolvedValueOnce({ data: { payment: mockPayment } })
+    vi.mocked(paymentApi.verify).mockResolvedValueOnce({
+      data: { payment: { ...mockPayment, status: 'uspesno' } },
+    })
+
+    const wrapper = mount(ClientNewPaymentView)
+    await flushPromises()
+
+    const selects = wrapper.findAll('select')
+    await selects[0].setValue('1')
+    await selects[1].setValue('10')
+    await wrapper.find('input[type="number"]').setValue('5000')
+    await wrapper.find('input[placeholder="Svrha plaćanja"]').setValue('Struja')
+    await wrapper.find('button.btn-primary').trigger('click')
+    await wrapper.findAll('button').find(b => b.text().includes('Potvrdi'))!.trigger('click')
+    await flushPromises()
+
+    await wrapper.find('input[maxlength="6"]').setValue('123456')
+    await wrapper.findAll('button').find(b => b.text() === 'Potvrdi kod')!.trigger('click')
+    await flushPromises()
+
+    expect(paymentApi.verify).toHaveBeenCalledWith('p1', '123456')
+    expect(wrapper.text()).toContain('uspešno realizovano')
+  })
+
+  it('wrong verification code shows error', async () => {
+    vi.mocked(paymentApi.create).mockResolvedValueOnce({ data: { payment: mockPayment } })
+    vi.mocked(paymentApi.verify).mockRejectedValueOnce({
+      response: { data: { message: 'Neispravan kod' } },
+    })
+
+    const wrapper = mount(ClientNewPaymentView)
+    await flushPromises()
+
+    const selects = wrapper.findAll('select')
+    await selects[0].setValue('1')
+    await selects[1].setValue('10')
+    await wrapper.find('input[type="number"]').setValue('5000')
+    await wrapper.find('input[placeholder="Svrha plaćanja"]').setValue('Struja')
+    await wrapper.find('button.btn-primary').trigger('click')
+    await wrapper.findAll('button').find(b => b.text().includes('Potvrdi'))!.trigger('click')
+    await flushPromises()
+
+    await wrapper.find('input[maxlength="6"]').setValue('000000')
+    await wrapper.findAll('button').find(b => b.text() === 'Potvrdi kod')!.trigger('click')
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Neispravan kod')
+  })
+
+  it('success step has Novo plaćanje button that resets form', async () => {
+    vi.mocked(paymentApi.create).mockResolvedValueOnce({ data: { payment: mockPayment } })
+    vi.mocked(paymentApi.verify).mockResolvedValueOnce({
+      data: { payment: { ...mockPayment, status: 'uspesno' } },
+    })
+
+    const wrapper = mount(ClientNewPaymentView)
+    await flushPromises()
+
+    const selects = wrapper.findAll('select')
+    await selects[0].setValue('1')
+    await selects[1].setValue('10')
+    await wrapper.find('input[type="number"]').setValue('5000')
+    await wrapper.find('input[placeholder="Svrha plaćanja"]').setValue('Struja')
+    await wrapper.find('button.btn-primary').trigger('click')
+    await wrapper.findAll('button').find(b => b.text().includes('Potvrdi'))!.trigger('click')
+    await flushPromises()
+    await wrapper.find('input[maxlength="6"]').setValue('123456')
+    await wrapper.findAll('button').find(b => b.text() === 'Potvrdi kod')!.trigger('click')
+    await flushPromises()
+
+    await wrapper.findAll('button').find(b => b.text() === 'Novo plaćanje')!.trigger('click')
+    expect(wrapper.text()).toContain('Sa računa')
+  })
+})

--- a/src/api/payment.ts
+++ b/src/api/payment.ts
@@ -1,0 +1,93 @@
+import clientApi from './clientAuth'
+
+export interface PaymentItem {
+  id: string
+  racunPosiljaocaId: string
+  racunPrimaocaBroj: string
+  iznos: number
+  sifraPlacanja: string
+  pozivNaBroj: string
+  svrha: string
+  status: string
+  verifikacioniKod?: string
+  vremeTransakcije: string
+}
+
+export interface CreatePaymentPayload {
+  racunPosiljaocaId: number
+  racunPrimaocaBroj: string
+  iznos: number
+  sifraPlacanja: string
+  pozivNaBroj: string
+  svrha: string
+  recipientId?: number
+}
+
+export interface PaymentFilter {
+  status?: string
+  dateFrom?: string
+  dateTo?: string
+  minAmount?: number
+  maxAmount?: number
+  page?: number
+  pageSize?: number
+}
+
+export const SIFRE_PLACANJA = [
+  { sifra: '221', naziv: 'Plaćanje robe' },
+  { sifra: '222', naziv: 'Plaćanje usluga' },
+  { sifra: '240', naziv: 'Komunalne usluge' },
+  { sifra: '253', naziv: 'Osiguranje' },
+  { sifra: '254', naziv: 'Prenos sredstava' },
+  { sifra: '265', naziv: 'Uplata kredita' },
+  { sifra: '270', naziv: 'Donacija' },
+  { sifra: '289', naziv: 'Ostala plaćanja' },
+  { sifra: '290', naziv: 'Interno plaćanje' },
+]
+
+export const paymentApi = {
+  create: (data: CreatePaymentPayload) =>
+    clientApi.post('/payments', {
+      racun_posiljaoca_id:  data.racunPosiljaocaId,
+      racun_primaoca_broj:  data.racunPrimaocaBroj,
+      iznos:                data.iznos,
+      sifra_placanja:       data.sifraPlacanja,
+      poziv_na_broj:        data.pozivNaBroj,
+      svrha:                data.svrha,
+      recipient_id:         data.recipientId,
+    }),
+
+  verify: (paymentId: string, verificationCode: string) =>
+    clientApi.post(`/payments/${paymentId}/verify`, {
+      verification_code: verificationCode,
+    }),
+
+  listByClient: (clientId: string, filter: PaymentFilter = {}) =>
+    clientApi.get(`/payments/client/${clientId}`, {
+      params: {
+        status:     filter.status,
+        date_from:  filter.dateFrom,
+        date_to:    filter.dateTo,
+        min_amount: filter.minAmount,
+        max_amount: filter.maxAmount,
+        page:       filter.page,
+        page_size:  filter.pageSize,
+      },
+    }),
+
+  listByAccount: (accountId: string, filter: PaymentFilter = {}) =>
+    clientApi.get(`/payments/account/${accountId}`, {
+      params: {
+        status:     filter.status,
+        date_from:  filter.dateFrom,
+        date_to:    filter.dateTo,
+        min_amount: filter.minAmount,
+        max_amount: filter.maxAmount,
+        page:       filter.page,
+        page_size:  filter.pageSize,
+      },
+    }),
+
+  get: (id: string) =>
+    clientApi.get(`/payments/${id}`),
+}

--- a/src/router/clientRoutes.ts
+++ b/src/router/clientRoutes.ts
@@ -36,6 +36,10 @@ export const clientRoutes: RouteRecordRaw[] = [
         path: 'payments',
         component: () => import('../views/client/ClientPaymentsView.vue'),
       },
+      {
+        path: 'payments/new',
+        component: () => import('../views/client/ClientNewPaymentView.vue'),
+      },
     ],
   },
 ]

--- a/src/stores/payment.ts
+++ b/src/stores/payment.ts
@@ -1,0 +1,42 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import { paymentApi, type PaymentItem, type CreatePaymentPayload, type PaymentFilter } from '../api/payment'
+
+export const usePaymentStore = defineStore('payment', () => {
+  const payments = ref<PaymentItem[]>([])
+  const total = ref(0)
+  const page = ref(1)
+  const pageSize = 20
+  const loading = ref(false)
+  const error = ref('')
+
+  async function createPayment(data: CreatePaymentPayload): Promise<PaymentItem> {
+    const res = await paymentApi.create(data)
+    return res.data.payment
+  }
+
+  async function verifyPayment(paymentId: string, verificationCode: string): Promise<PaymentItem> {
+    const res = await paymentApi.verify(paymentId, verificationCode)
+    return res.data.payment
+  }
+
+  async function fetchByClient(clientId: string, filter: PaymentFilter = {}) {
+    loading.value = true
+    error.value = ''
+    try {
+      const res = await paymentApi.listByClient(clientId, { ...filter, page: page.value, pageSize })
+      payments.value = res.data.payments ?? []
+      total.value = Number(res.data.total ?? 0)
+    } catch (e: any) {
+      error.value = e.response?.data?.message || 'Failed to load payments.'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  function clearError() {
+    error.value = ''
+  }
+
+  return { payments, total, page, pageSize, loading, error, createPayment, verifyPayment, fetchByClient, clearError }
+})

--- a/src/views/client/ClientNewPaymentView.vue
+++ b/src/views/client/ClientNewPaymentView.vue
@@ -1,0 +1,286 @@
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+import { useClientAuthStore } from '../../stores/clientAuth'
+import { useClientAccountStore } from '../../stores/clientAccount'
+import { useRecipientStore } from '../../stores/recipient'
+import { usePaymentStore } from '../../stores/payment'
+import { SIFRE_PLACANJA } from '../../api/payment'
+import type { PaymentItem } from '../../api/payment'
+
+const router = useRouter()
+const clientAuthStore = useClientAuthStore()
+const accountStore = useClientAccountStore()
+const recipientStore = useRecipientStore()
+const paymentStore = usePaymentStore()
+
+const clientId = computed(() => String(clientAuthStore.client?.id ?? ''))
+
+// 4-step flow: form → confirm → verify → success
+const step = ref<'form' | 'confirm' | 'verify' | 'success'>('form')
+
+const form = ref({
+  fromAccountId: '',
+  recipientMode: 'saved' as 'saved' | 'manual',
+  savedRecipientId: '',
+  manualBrojRacuna: '',
+  iznos: '',
+  sifraPlacanja: '289',
+  pozivNaBroj: '',
+  svrha: '',
+})
+
+const createdPayment = ref<PaymentItem | null>(null)
+const verificationCode = ref('')
+const verifyError = ref('')
+const formError = ref('')
+
+const receiverBrojRacuna = computed(() => {
+  if (form.value.recipientMode === 'saved') {
+    const r = recipientStore.recipients.find(r => r.id === form.value.savedRecipientId)
+    return r?.brojRacuna ?? ''
+  }
+  return form.value.manualBrojRacuna
+})
+
+const fromAccount = computed(() =>
+  accountStore.accounts.find(a => String(a.id) === form.value.fromAccountId) ?? null
+)
+
+const selectedSifra = computed(() =>
+  SIFRE_PLACANJA.find(s => s.sifra === form.value.sifraPlacanja)
+)
+
+function fillFromRecipient(recipientId: string) {
+  form.value.savedRecipientId = recipientId
+}
+
+function goToConfirm() {
+  formError.value = ''
+  if (!form.value.fromAccountId) { formError.value = 'Izaberite izvorni račun.'; return }
+  if (!receiverBrojRacuna.value) { formError.value = 'Unesite broj računa primaoca.'; return }
+  if (!form.value.iznos || Number(form.value.iznos) <= 0) { formError.value = 'Unesite validan iznos.'; return }
+  if (!form.value.svrha.trim()) { formError.value = 'Unesite svrhu plaćanja.'; return }
+  step.value = 'confirm'
+}
+
+async function handleSubmit() {
+  try {
+    const payment = await paymentStore.createPayment({
+      racunPosiljaocaId: Number(form.value.fromAccountId),
+      racunPrimaocaBroj: receiverBrojRacuna.value,
+      iznos: Number(form.value.iznos),
+      sifraPlacanja: form.value.sifraPlacanja,
+      pozivNaBroj: form.value.pozivNaBroj,
+      svrha: form.value.svrha,
+      recipientId: form.value.recipientMode === 'saved' && form.value.savedRecipientId
+        ? Number(form.value.savedRecipientId)
+        : undefined,
+    })
+    createdPayment.value = payment
+    step.value = 'verify'
+  } catch (e: any) {
+    formError.value = e.response?.data?.message || 'Greška pri kreiranju plaćanja.'
+    step.value = 'form'
+  }
+}
+
+async function handleVerify() {
+  if (!verificationCode.value || verificationCode.value.length !== 6) {
+    verifyError.value = 'Unesite 6-cifreni verifikacioni kod.'
+    return
+  }
+  verifyError.value = ''
+  try {
+    await paymentStore.verifyPayment(createdPayment.value!.id, verificationCode.value)
+    step.value = 'success'
+  } catch (e: any) {
+    verifyError.value = e.response?.data?.message || 'Neispravan verifikacioni kod.'
+  }
+}
+
+function startNew() {
+  form.value = {
+    fromAccountId: '', recipientMode: 'saved', savedRecipientId: '',
+    manualBrojRacuna: '', iznos: '', sifraPlacanja: '289', pozivNaBroj: '', svrha: '',
+  }
+  verificationCode.value = ''
+  verifyError.value = ''
+  formError.value = ''
+  createdPayment.value = null
+  step.value = 'form'
+}
+
+onMounted(async () => {
+  if (clientId.value) {
+    await Promise.all([
+      accountStore.fetchAccounts(clientId.value),
+      recipientStore.fetchRecipients(clientId.value),
+    ])
+  }
+})
+</script>
+
+<template>
+  <div class="page-container">
+    <h1 class="page-title">Novo plaćanje</h1>
+
+    <div class="card">
+      <div class="card-body">
+
+        <!-- Step: Form -->
+        <div v-if="step === 'form'">
+          <div class="form-group">
+            <label>Sa računa</label>
+            <select v-model="form.fromAccountId" class="form-input">
+              <option value="">-- Izaberite račun --</option>
+              <option v-for="acc in accountStore.accounts" :key="acc.id" :value="String(acc.id)">
+                {{ acc.naziv || acc.brojRacuna }} ({{ acc.currencyKod }}) — {{ acc.raspolozivoStanje.toLocaleString('sr-RS') }}
+              </option>
+            </select>
+          </div>
+
+          <div class="form-group">
+            <label>Način unosa primaoca</label>
+            <div class="radio-group">
+              <label>
+                <input v-model="form.recipientMode" type="radio" value="saved" />
+                Sačuvani primalac
+              </label>
+              <label>
+                <input v-model="form.recipientMode" type="radio" value="manual" />
+                Ručni unos
+              </label>
+            </div>
+          </div>
+
+          <div v-if="form.recipientMode === 'saved'" class="form-group">
+            <label>Primalac</label>
+            <select v-model="form.savedRecipientId" class="form-input" @change="fillFromRecipient(form.savedRecipientId)">
+              <option value="">-- Izaberite primaoca --</option>
+              <option v-for="r in recipientStore.recipients" :key="r.id" :value="r.id">
+                {{ r.naziv }} — {{ r.brojRacuna }}
+              </option>
+            </select>
+          </div>
+
+          <div v-else class="form-group">
+            <label>Broj računa primaoca</label>
+            <input v-model="form.manualBrojRacuna" type="text" class="form-input" placeholder="Broj računa primaoca" />
+          </div>
+
+          <div class="form-group">
+            <label>Iznos</label>
+            <input v-model="form.iznos" type="number" min="0.01" step="0.01" class="form-input" placeholder="0.00" />
+          </div>
+
+          <div class="form-group">
+            <label>Šifra plaćanja</label>
+            <select v-model="form.sifraPlacanja" class="form-input">
+              <option v-for="s in SIFRE_PLACANJA" :key="s.sifra" :value="s.sifra">
+                {{ s.sifra }} — {{ s.naziv }}
+              </option>
+            </select>
+          </div>
+
+          <div class="form-group">
+            <label>Poziv na broj</label>
+            <input v-model="form.pozivNaBroj" type="text" class="form-input" placeholder="Poziv na broj" />
+          </div>
+
+          <div class="form-group">
+            <label>Svrha plaćanja</label>
+            <input v-model="form.svrha" type="text" class="form-input" placeholder="Svrha plaćanja" />
+          </div>
+
+          <div v-if="formError" class="error-message">{{ formError }}</div>
+
+          <button class="btn btn-primary" @click="goToConfirm">Dalje</button>
+        </div>
+
+        <!-- Step: Confirm -->
+        <div v-else-if="step === 'confirm'">
+          <h3>Pregled plaćanja</h3>
+          <table class="detail-table">
+            <tbody>
+              <tr>
+                <th>Sa računa</th>
+                <td>{{ fromAccount?.naziv || fromAccount?.brojRacuna }} ({{ fromAccount?.currencyKod }})</td>
+              </tr>
+              <tr>
+                <th>Primalac</th>
+                <td>{{ receiverBrojRacuna }}</td>
+              </tr>
+              <tr>
+                <th>Iznos</th>
+                <td>{{ Number(form.iznos).toLocaleString('sr-RS') }} {{ fromAccount?.currencyKod }}</td>
+              </tr>
+              <tr>
+                <th>Šifra plaćanja</th>
+                <td>{{ form.sifraPlacanja }} — {{ selectedSifra?.naziv }}</td>
+              </tr>
+              <tr>
+                <th>Poziv na broj</th>
+                <td>{{ form.pozivNaBroj || '—' }}</td>
+              </tr>
+              <tr>
+                <th>Svrha</th>
+                <td>{{ form.svrha }}</td>
+              </tr>
+            </tbody>
+          </table>
+
+          <div v-if="formError" class="error-message">{{ formError }}</div>
+
+          <div class="action-row">
+            <button class="btn btn-secondary" @click="step = 'form'">Nazad</button>
+            <button class="btn btn-primary" :disabled="paymentStore.loading" @click="handleSubmit">
+              {{ paymentStore.loading ? 'Šaljem...' : 'Potvrdi' }}
+            </button>
+          </div>
+        </div>
+
+        <!-- Step: Verify -->
+        <div v-else-if="step === 'verify'">
+          <h3>Verifikacija plaćanja</h3>
+          <p class="text-muted">Unesite 6-cifreni verifikacioni kod koji ste primili.</p>
+
+          <div class="form-group">
+            <label>Verifikacioni kod</label>
+            <input
+              v-model="verificationCode"
+              type="text"
+              maxlength="6"
+              class="form-input"
+              placeholder="------"
+            />
+          </div>
+
+          <div v-if="verifyError" class="error-message">{{ verifyError }}</div>
+
+          <div class="action-row">
+            <button class="btn btn-secondary" @click="step = 'confirm'">Nazad</button>
+            <button
+              class="btn btn-primary"
+              :disabled="verificationCode.length !== 6"
+              @click="handleVerify"
+            >
+              Potvrdi kod
+            </button>
+          </div>
+        </div>
+
+        <!-- Step: Success -->
+        <div v-else-if="step === 'success'" class="success-box">
+          <div class="success-icon">✓</div>
+          <p>Plaćanje je uspešno realizovano!</p>
+          <div class="action-row">
+            <button class="btn btn-secondary" @click="router.push('/client/payments')">Pregled plaćanja</button>
+            <button class="btn btn-primary" @click="startNew">Novo plaćanje</button>
+          </div>
+        </div>
+
+      </div>
+    </div>
+  </div>
+</template>


### PR DESCRIPTION
Implements Issue #67 (PAYMENTS-FE-1):

- paymentApi (create, verify, listByClient, listByAccount, get) + SIFRE_PLACANJA constants
- usePaymentStore (Pinia store with createPayment, verifyPayment, fetchByClient)
- ClientNewPaymentView: 4-step flow — form (source account, saved/manual recipient, amount, sifra, poziv na broj, svrha) → confirm (summary) → verify (6-digit code) → success
- Route added: /client/payments/new
- 7 store tests + 13 view tests, all 143 tests passing

Fixes #67