### PR TITLE
feat(PAYMENTS-FE-2): payment overview with filters, status badges and detail modal - Fixes #68

### DIFF
--- a/src/__tests__/views/ClientPaymentsView.test.ts
+++ b/src/__tests__/views/ClientPaymentsView.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import ClientPaymentsView from '../../views/client/ClientPaymentsView.vue'
+import { useClientAuthStore } from '../../stores/clientAuth'
+
+const mockPush = vi.fn()
+
+vi.mock('vue-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('vue-router')>()
+  return { ...actual, useRouter: () => ({ push: mockPush }) }
+})
+
+vi.mock('../../api/payment', () => ({
+  paymentApi: {
+    create: vi.fn(),
+    verify: vi.fn(),
+    listByClient: vi.fn(),
+    listByAccount: vi.fn(),
+    get: vi.fn(),
+  },
+  SIFRE_PLACANJA: [],
+}))
+
+vi.mock('../../api/clientAuth', () => ({
+  clientAuthApi: { login: vi.fn() },
+  default: { get: vi.fn(), post: vi.fn(), interceptors: { request: { use: vi.fn() } } },
+}))
+
+import { paymentApi } from '../../api/payment'
+
+const mockPayments = [
+  {
+    id: '1',
+    racunPosiljaocaId: '10',
+    racunPrimaocaBroj: '111111111111111111',
+    iznos: 5000,
+    sifraPlacanja: '289',
+    pozivNaBroj: '97-123',
+    svrha: 'Kirija',
+    status: 'uspesno',
+    vremeTransakcije: '2026-03-01T10:00:00Z',
+  },
+  {
+    id: '2',
+    racunPosiljaocaId: '10',
+    racunPrimaocaBroj: '222222222222222222',
+    iznos: 1200,
+    sifraPlacanja: '240',
+    pozivNaBroj: '',
+    svrha: 'Struja',
+    status: 'u_obradi',
+    vremeTransakcije: '2026-03-02T12:00:00Z',
+  },
+  {
+    id: '3',
+    racunPosiljaocaId: '10',
+    racunPrimaocaBroj: '333333333333333333',
+    iznos: 800,
+    sifraPlacanja: '222',
+    pozivNaBroj: '',
+    svrha: 'Internet',
+    status: 'stornirano',
+    vremeTransakcije: '2026-03-03T08:00:00Z',
+  },
+]
+
+describe('ClientPaymentsView', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+
+    const authStore = useClientAuthStore()
+    authStore.accessToken = 'test-token'
+    authStore.client = { id: '5', ime: 'Ana', prezime: 'Jović', email: 'ana@gmail.com', permissions: ['client.basic'] }
+
+    vi.mocked(paymentApi.listByClient).mockResolvedValue({
+      data: { payments: mockPayments, total: 3 },
+    })
+  })
+
+  it('renders Plaćanja heading', async () => {
+    const wrapper = mount(ClientPaymentsView)
+    await flushPromises()
+    expect(wrapper.text()).toContain('Plaćanja')
+  })
+
+  it('loads payments on mount', async () => {
+    mount(ClientPaymentsView)
+    await flushPromises()
+    expect(paymentApi.listByClient).toHaveBeenCalledWith('5', expect.any(Object))
+  })
+
+  it('shows payment rows in table', async () => {
+    const wrapper = mount(ClientPaymentsView)
+    await flushPromises()
+    const rows = wrapper.findAll('.payment-row')
+    expect(rows).toHaveLength(3)
+  })
+
+  it('shows recipient account, amount and svrha', async () => {
+    const wrapper = mount(ClientPaymentsView)
+    await flushPromises()
+    expect(wrapper.text()).toContain('111111111111111111')
+    expect(wrapper.text()).toContain('Kirija')
+    expect(wrapper.text()).toContain('Struja')
+  })
+
+  it('shows status badges for each payment', async () => {
+    const wrapper = mount(ClientPaymentsView)
+    await flushPromises()
+    expect(wrapper.text()).toContain('uspesno')
+    expect(wrapper.text()).toContain('u_obradi')
+    expect(wrapper.text()).toContain('stornirano')
+  })
+
+  it('uspesno badge has badge-success class', async () => {
+    const wrapper = mount(ClientPaymentsView)
+    await flushPromises()
+    const badge = wrapper.findAll('.badge').find(b => b.text() === 'uspesno')
+    expect(badge!.classes()).toContain('badge-success')
+  })
+
+  it('u_obradi badge has badge-warning class', async () => {
+    const wrapper = mount(ClientPaymentsView)
+    await flushPromises()
+    const badge = wrapper.findAll('.badge').find(b => b.text() === 'u_obradi')
+    expect(badge!.classes()).toContain('badge-warning')
+  })
+
+  it('stornirano badge has badge-neutral class', async () => {
+    const wrapper = mount(ClientPaymentsView)
+    await flushPromises()
+    const badge = wrapper.findAll('.badge').find(b => b.text() === 'stornirano')
+    expect(badge!.classes()).toContain('badge-neutral')
+  })
+
+  it('shows empty state when no payments', async () => {
+    vi.mocked(paymentApi.listByClient).mockResolvedValueOnce({
+      data: { payments: [], total: 0 },
+    })
+    const wrapper = mount(ClientPaymentsView)
+    await flushPromises()
+    expect(wrapper.text()).toContain('Nema plaćanja')
+  })
+
+  it('clicking a row opens detail modal', async () => {
+    const wrapper = mount(ClientPaymentsView)
+    await flushPromises()
+
+    expect(wrapper.find('.modal-overlay').exists()).toBe(false)
+    await wrapper.find('.payment-row').trigger('click')
+    expect(wrapper.find('.modal-overlay').exists()).toBe(true)
+    expect(wrapper.text()).toContain('Detalji plaćanja')
+  })
+
+  it('detail modal shows all payment fields', async () => {
+    const wrapper = mount(ClientPaymentsView)
+    await flushPromises()
+
+    await wrapper.find('.payment-row').trigger('click')
+
+    expect(wrapper.text()).toContain('111111111111111111')
+    expect(wrapper.text()).toContain('Kirija')
+    expect(wrapper.text()).toContain('97-123')
+    expect(wrapper.text()).toContain('289')
+  })
+
+  it('modal close button hides modal', async () => {
+    const wrapper = mount(ClientPaymentsView)
+    await flushPromises()
+
+    await wrapper.find('.payment-row').trigger('click')
+    expect(wrapper.find('.modal-overlay').exists()).toBe(true)
+
+    await wrapper.find('.modal-close').trigger('click')
+    expect(wrapper.find('.modal-overlay').exists()).toBe(false)
+  })
+
+  it('Novo plaćanje button navigates to /client/payments/new', async () => {
+    const wrapper = mount(ClientPaymentsView)
+    await flushPromises()
+
+    await wrapper.findAll('button').find(b => b.text().includes('Novo plaćanje'))!.trigger('click')
+    expect(mockPush).toHaveBeenCalledWith('/client/payments/new')
+  })
+
+  it('shows filter dropdowns and date inputs', async () => {
+    const wrapper = mount(ClientPaymentsView)
+    await flushPromises()
+    expect(wrapper.text()).toContain('Svi statusi')
+    expect(wrapper.findAll('input[type="date"]')).toHaveLength(2)
+  })
+
+  it('changing status filter calls API with filter param', async () => {
+    vi.mocked(paymentApi.listByClient).mockResolvedValue({
+      data: { payments: [], total: 0 },
+    })
+
+    const wrapper = mount(ClientPaymentsView)
+    await flushPromises()
+
+    await wrapper.find('select').setValue('uspesno')
+    await flushPromises()
+
+    expect(paymentApi.listByClient).toHaveBeenCalledWith('5',
+      expect.objectContaining({ status: 'uspesno' })
+    )
+  })
+})

--- a/src/views/client/ClientPaymentsView.vue
+++ b/src/views/client/ClientPaymentsView.vue
@@ -1,9 +1,192 @@
 <script setup lang="ts">
+import { ref, computed, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+import { usePaymentStore } from '../../stores/payment'
+import { useClientAuthStore } from '../../stores/clientAuth'
+import type { PaymentItem } from '../../api/payment'
+
+const router = useRouter()
+const clientAuthStore = useClientAuthStore()
+const paymentStore = usePaymentStore()
+
+const clientId = computed(() => String(clientAuthStore.client?.id ?? ''))
+
+// Detail modal
+const selectedPayment = ref<PaymentItem | null>(null)
+
+function openDetail(p: PaymentItem) {
+  selectedPayment.value = p
+}
+
+function closeDetail() {
+  selectedPayment.value = null
+}
+
+// Filters
+const filter = ref({ status: '', dateFrom: '', dateTo: '' })
+
+async function applyFilter() {
+  paymentStore.page = 1
+  await paymentStore.fetchByClient(clientId.value, {
+    status:   filter.value.status   || undefined,
+    dateFrom: filter.value.dateFrom || undefined,
+    dateTo:   filter.value.dateTo   || undefined,
+  })
+}
+
+async function prevPage() {
+  if (paymentStore.page > 1) {
+    paymentStore.page--
+    await applyFilter()
+  }
+}
+
+async function nextPage() {
+  if (paymentStore.page * paymentStore.pageSize < paymentStore.total) {
+    paymentStore.page++
+    await applyFilter()
+  }
+}
+
+const totalPages = computed(() =>
+  Math.ceil(paymentStore.total / paymentStore.pageSize) || 1
+)
+
+function statusBadgeClass(status: string) {
+  switch (status) {
+    case 'uspesno':    return 'badge-success'
+    case 'neuspesno':  return 'badge-error'
+    case 'u_obradi':   return 'badge-warning'
+    case 'stornirano': return 'badge-neutral'
+    default:           return 'badge-neutral'
+  }
+}
+
+onMounted(async () => {
+  if (clientId.value) await paymentStore.fetchByClient(clientId.value)
+})
 </script>
 
 <template>
   <div class="page-container">
-    <h1>ClientPaymentsView</h1>
-    <p>Coming soon</p>
+    <div class="page-header">
+      <h1 class="page-title">Plaćanja</h1>
+      <button class="btn btn-primary" @click="router.push('/client/payments/new')">+ Novo plaćanje</button>
+    </div>
+
+    <div class="card">
+      <div class="card-body">
+
+        <!-- Filters -->
+        <div class="filter-row">
+          <select v-model="filter.status" class="form-input filter-input" @change="applyFilter">
+            <option value="">Svi statusi</option>
+            <option value="u_obradi">U obradi</option>
+            <option value="uspesno">Uspešno</option>
+            <option value="neuspesno">Neuspešno</option>
+            <option value="stornirano">Stornirano</option>
+          </select>
+          <input v-model="filter.dateFrom" type="date" class="form-input filter-input" @change="applyFilter" />
+          <input v-model="filter.dateTo"   type="date" class="form-input filter-input" @change="applyFilter" />
+        </div>
+
+        <div v-if="paymentStore.loading" class="loading-msg">Učitavam...</div>
+        <div v-else-if="paymentStore.error" class="error-message">{{ paymentStore.error }}</div>
+        <div v-else-if="paymentStore.payments.length === 0" class="empty-msg">Nema plaćanja.</div>
+        <table v-else class="data-table">
+          <thead>
+            <tr>
+              <th>Datum</th>
+              <th>Primalac</th>
+              <th>Iznos</th>
+              <th>Svrha</th>
+              <th>Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              v-for="p in paymentStore.payments"
+              :key="p.id"
+              class="payment-row clickable-row"
+              @click="openDetail(p)"
+            >
+              <td>{{ new Date(p.vremeTransakcije).toLocaleDateString('sr-RS') }}</td>
+              <td>{{ p.racunPrimaocaBroj }}</td>
+              <td>{{ p.iznos.toLocaleString('sr-RS') }}</td>
+              <td>{{ p.svrha }}</td>
+              <td><span :class="['badge', statusBadgeClass(p.status)]">{{ p.status }}</span></td>
+            </tr>
+          </tbody>
+        </table>
+
+        <!-- Pagination -->
+        <div v-if="paymentStore.total > paymentStore.pageSize" class="pagination">
+          <button class="btn btn-secondary" :disabled="paymentStore.page <= 1" @click="prevPage">‹</button>
+          <span>{{ paymentStore.page }} / {{ totalPages }}</span>
+          <button class="btn btn-secondary" :disabled="paymentStore.page >= totalPages" @click="nextPage">›</button>
+        </div>
+
+      </div>
+    </div>
+
+    <!-- Detail Modal -->
+    <div v-if="selectedPayment" class="modal-overlay" @click.self="closeDetail">
+      <div class="modal-box">
+        <div class="modal-header">
+          <h2>Detalji plaćanja</h2>
+          <button class="modal-close" @click="closeDetail">✕</button>
+        </div>
+        <div class="modal-body">
+          <table class="detail-table">
+            <tbody>
+              <tr>
+                <th>ID</th>
+                <td>{{ selectedPayment.id }}</td>
+              </tr>
+              <tr>
+                <th>Sa računa</th>
+                <td>{{ selectedPayment.racunPosiljaocaId }}</td>
+              </tr>
+              <tr>
+                <th>Primalac (broj računa)</th>
+                <td>{{ selectedPayment.racunPrimaocaBroj }}</td>
+              </tr>
+              <tr>
+                <th>Iznos</th>
+                <td>{{ selectedPayment.iznos.toLocaleString('sr-RS') }}</td>
+              </tr>
+              <tr>
+                <th>Šifra plaćanja</th>
+                <td>{{ selectedPayment.sifraPlacanja }}</td>
+              </tr>
+              <tr>
+                <th>Poziv na broj</th>
+                <td>{{ selectedPayment.pozivNaBroj || '—' }}</td>
+              </tr>
+              <tr>
+                <th>Svrha</th>
+                <td>{{ selectedPayment.svrha }}</td>
+              </tr>
+              <tr>
+                <th>Status</th>
+                <td>
+                  <span :class="['badge', statusBadgeClass(selectedPayment.status)]">
+                    {{ selectedPayment.status }}
+                  </span>
+                </td>
+              </tr>
+              <tr>
+                <th>Datum</th>
+                <td>{{ new Date(selectedPayment.vremeTransakcije).toLocaleString('sr-RS') }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <div class="modal-footer">
+          <button class="btn btn-secondary" @click="closeDetail">Zatvori</button>
+        </div>
+      </div>
+    </div>
+
   </div>
 </template>


### PR DESCRIPTION
Implements Issue #68 (PAYMENTS-FE-2):

- ClientPaymentsView: payment list with status/date filters, status badges (success/warning/error/neutral), click-to-open detail modal showing all payment fields
- Novo plaćanje button navigates to /client/payments/new
- Pagination support
- 15 view tests, all 158 tests passing

Fixes #68