### PR TITLE
feat(DASHBOARD-FE-1): client dashboard with all 6 sections including real quick payment - Fixes #18

### DIFF
--- a/src/__tests__/views/ClientDashboardView.test.ts
+++ b/src/__tests__/views/ClientDashboardView.test.ts
@@ -1,0 +1,295 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import ClientDashboardView from '../../views/client/ClientDashboardView.vue'
+import { useClientAuthStore } from '../../stores/clientAuth'
+
+vi.mock('../../api/exchange', () => ({
+  exchangeApi: { getRates: vi.fn(), calculate: vi.fn() },
+}))
+
+vi.mock('../../api/payment', () => ({
+  paymentApi: { create: vi.fn(), verify: vi.fn(), listByClient: vi.fn(), listByAccount: vi.fn(), get: vi.fn() },
+  SIFRE_PLACANJA: [],
+}))
+
+vi.mock('../../api/clientAccount', () => ({
+  clientAccountApi: { listByClient: vi.fn(), get: vi.fn() },
+}))
+
+vi.mock('../../api/transfer', () => ({
+  transferApi: { create: vi.fn(), listByClient: vi.fn(), listByAccount: vi.fn(), calculateExchange: vi.fn() },
+}))
+
+vi.mock('../../api/recipient', () => ({
+  recipientApi: { listByClient: vi.fn(), create: vi.fn(), update: vi.fn(), delete: vi.fn() },
+}))
+
+vi.mock('../../api/clientAuth', () => ({
+  clientAuthApi: { login: vi.fn() },
+  default: { get: vi.fn(), post: vi.fn(), interceptors: { request: { use: vi.fn() } } },
+}))
+
+import { exchangeApi } from '../../api/exchange'
+import { paymentApi } from '../../api/payment'
+import { clientAccountApi } from '../../api/clientAccount'
+import { transferApi } from '../../api/transfer'
+import { recipientApi } from '../../api/recipient'
+
+const mockAccounts = [
+  {
+    id: '1', brojRacuna: '111111111111111111', clientId: '5', firmaId: '0',
+    currencyId: '1', currencyKod: 'RSD', tip: 'tekuci', vrsta: 'licni',
+    stanje: 50000, raspolozivoStanje: 50000, dnevniLimit: 100000, mesecniLimit: 1000000,
+    naziv: 'RSD račun', status: 'aktivan',
+  },
+  {
+    id: '2', brojRacuna: '222222222222222222', clientId: '5', firmaId: '0',
+    currencyId: '2', currencyKod: 'EUR', tip: 'devizni', vrsta: 'licni',
+    stanje: 500, raspolozivoStanje: 450, dnevniLimit: 10000, mesecniLimit: 100000,
+    naziv: 'EUR račun', status: 'aktivan',
+  },
+]
+
+const mockTransfers = [
+  {
+    id: 't1', racunPosiljaocaId: '1', racunPrimaocaId: '2',
+    iznos: 1000, valutaIznosa: 'RSD', konvertovaniIznos: 1000, kurs: 1,
+    svrha: 'Kirija', status: 'uspesno', vremeTransakcije: '2026-03-01T10:00:00Z',
+  },
+]
+
+const mockPayments = [
+  {
+    id: 'p1', racunPosiljaocaId: '1', racunPrimaocaBroj: '999999999999999999',
+    iznos: 1200, sifraPlacanja: '240', pozivNaBroj: '', svrha: 'Struja',
+    status: 'u_obradi', vremeTransakcije: '2026-03-02T12:00:00Z',
+  },
+]
+
+const mockRates = [
+  { from: 'EUR', to: 'RSD', rate: 117.5 },
+  { from: 'USD', to: 'RSD', rate: 108.8 },
+]
+
+const mockRecipients = [
+  { id: '10', clientId: '5', naziv: 'EPS', brojRacuna: '999999999999999999' },
+  { id: '11', clientId: '5', naziv: 'Telenor', brojRacuna: '888888888888888888' },
+]
+
+describe('ClientDashboardView', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+
+    const authStore = useClientAuthStore()
+    authStore.accessToken = 'test-token'
+    authStore.client = { id: '5', ime: 'Ana', prezime: 'Jović', email: 'ana@gmail.com', permissions: ['client.basic'] }
+
+    vi.mocked(clientAccountApi.listByClient).mockResolvedValue({ data: { accounts: mockAccounts } })
+    vi.mocked(transferApi.listByClient).mockResolvedValue({ data: { transfers: mockTransfers, total: 1 } })
+    vi.mocked(paymentApi.listByClient).mockResolvedValue({ data: { payments: mockPayments, total: 1 } })
+    vi.mocked(exchangeApi.getRates).mockResolvedValue({ data: { rates: mockRates } })
+    vi.mocked(recipientApi.listByClient).mockResolvedValue({ data: { recipients: mockRecipients } })
+  })
+
+  // Section 1: Accounts
+  it('renders welcome heading with client name', async () => {
+    const wrapper = mount(ClientDashboardView)
+    await flushPromises()
+    expect(wrapper.text()).toContain('Dobrodošli')
+    expect(wrapper.text()).toContain('Ana')
+  })
+
+  it('renders Moji računi section', async () => {
+    const wrapper = mount(ClientDashboardView)
+    await flushPromises()
+    expect(wrapper.text()).toContain('Moji računi')
+  })
+
+  it('shows account summary cards for each account', async () => {
+    const wrapper = mount(ClientDashboardView)
+    await flushPromises()
+    const cards = wrapper.findAll('.account-summary-card')
+    expect(cards).toHaveLength(2)
+    expect(wrapper.text()).toContain('RSD račun')
+    expect(wrapper.text()).toContain('EUR račun')
+  })
+
+  it('shows account balance in cards', async () => {
+    const wrapper = mount(ClientDashboardView)
+    await flushPromises()
+    expect(wrapper.text()).toContain('50.000')
+    expect(wrapper.text()).toContain('500')
+  })
+
+  // Section 2: Recent transactions
+  it('renders Poslednje transakcije section', async () => {
+    const wrapper = mount(ClientDashboardView)
+    await flushPromises()
+    expect(wrapper.text()).toContain('Poslednje transakcije')
+  })
+
+  it('shows combined recent transfers and payments', async () => {
+    const wrapper = mount(ClientDashboardView)
+    await flushPromises()
+    const rows = wrapper.findAll('.activity-row')
+    expect(rows).toHaveLength(2)
+    expect(wrapper.text()).toContain('Kirija')
+    expect(wrapper.text()).toContain('Struja')
+  })
+
+  // Section 3: Exchange rates
+  it('renders Kursna lista section', async () => {
+    const wrapper = mount(ClientDashboardView)
+    await flushPromises()
+    expect(wrapper.text()).toContain('Kursna lista')
+  })
+
+  it('loads and displays exchange rates', async () => {
+    const wrapper = mount(ClientDashboardView)
+    await flushPromises()
+    const rows = wrapper.findAll('.rate-row')
+    expect(rows).toHaveLength(2)
+    expect(wrapper.text()).toContain('EUR/RSD')
+    expect(wrapper.text()).toContain('117.5000')
+  })
+
+  // Section 4: Quick payment
+  it('renders Brzo plaćanje section', async () => {
+    const wrapper = mount(ClientDashboardView)
+    await flushPromises()
+    expect(wrapper.text()).toContain('Brzo plaćanje')
+  })
+
+  it('quick payment form shows account and recipient dropdowns', async () => {
+    const wrapper = mount(ClientDashboardView)
+    await flushPromises()
+    expect(wrapper.text()).toContain('EPS')
+    expect(wrapper.text()).toContain('RSD račun')
+  })
+
+  it('quick payment submit with empty fields shows error', async () => {
+    const wrapper = mount(ClientDashboardView)
+    await flushPromises()
+
+    const platiBtn = wrapper.findAll('button').find(b => b.text() === 'Plati')
+    await platiBtn!.trigger('click')
+    expect(wrapper.text()).toContain('Izaberite račun')
+  })
+
+  it('quick payment submit creates payment and moves to verify step', async () => {
+    vi.mocked(paymentApi.create).mockResolvedValueOnce({
+      data: { payment: { id: 'p99', status: 'u_obradi', iznos: 500, svrha: 'Brzo plaćanje',
+        racunPosiljaocaId: '1', racunPrimaocaBroj: '999999999999999999',
+        sifraPlacanja: '289', pozivNaBroj: '', verifikacioniKod: '654321',
+        vremeTransakcije: '2026-03-10T10:00:00Z' } },
+    })
+
+    const wrapper = mount(ClientDashboardView)
+    await flushPromises()
+
+    const selects = wrapper.findAll('select')
+    const fromSelect = selects.find(s => s.text().includes('Račun'))
+    const recipientSelect = selects.find(s => s.text().includes('Primalac'))
+    await fromSelect!.setValue('1')
+    await recipientSelect!.setValue('10')
+    await wrapper.find('input[type="number"]').setValue('500')
+
+    await wrapper.findAll('button').find(b => b.text() === 'Plati')!.trigger('click')
+    await flushPromises()
+
+    expect(paymentApi.create).toHaveBeenCalledOnce()
+    expect(wrapper.text()).toContain('verifikacioni kod')
+  })
+
+  it('quick payment verify with correct code shows success', async () => {
+    vi.mocked(paymentApi.create).mockResolvedValueOnce({
+      data: { payment: { id: 'p99', status: 'u_obradi', iznos: 500, svrha: 'Brzo plaćanje',
+        racunPosiljaocaId: '1', racunPrimaocaBroj: '999999999999999999',
+        sifraPlacanja: '289', pozivNaBroj: '', verifikacioniKod: '654321',
+        vremeTransakcije: '2026-03-10T10:00:00Z' } },
+    })
+    vi.mocked(paymentApi.verify).mockResolvedValueOnce({
+      data: { payment: { id: 'p99', status: 'uspesno' } },
+    })
+
+    const wrapper = mount(ClientDashboardView)
+    await flushPromises()
+
+    const selects = wrapper.findAll('select')
+    await selects.find(s => s.text().includes('Račun'))!.setValue('1')
+    await selects.find(s => s.text().includes('Primalac'))!.setValue('10')
+    await wrapper.find('input[type="number"]').setValue('500')
+    await wrapper.findAll('button').find(b => b.text() === 'Plati')!.trigger('click')
+    await flushPromises()
+
+    await wrapper.find('input[maxlength="6"]').setValue('654321')
+    await wrapper.findAll('button').find(b => b.text() === 'Potvrdi')!.trigger('click')
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Plaćanje uspešno')
+  })
+
+  it('quick payment reset after success returns to form', async () => {
+    vi.mocked(paymentApi.create).mockResolvedValueOnce({
+      data: { payment: { id: 'p99', status: 'u_obradi', iznos: 500, svrha: 'Brzo plaćanje',
+        racunPosiljaocaId: '1', racunPrimaocaBroj: '999999999999999999',
+        sifraPlacanja: '289', pozivNaBroj: '', vremeTransakcije: '2026-03-10T10:00:00Z' } },
+    })
+    vi.mocked(paymentApi.verify).mockResolvedValueOnce({
+      data: { payment: { id: 'p99', status: 'uspesno' } },
+    })
+
+    const wrapper = mount(ClientDashboardView)
+    await flushPromises()
+
+    const selects = wrapper.findAll('select')
+    await selects.find(s => s.text().includes('Račun'))!.setValue('1')
+    await selects.find(s => s.text().includes('Primalac'))!.setValue('10')
+    await wrapper.find('input[type="number"]').setValue('500')
+    await wrapper.findAll('button').find(b => b.text() === 'Plati')!.trigger('click')
+    await flushPromises()
+    await wrapper.find('input[maxlength="6"]').setValue('654321')
+    await wrapper.findAll('button').find(b => b.text() === 'Potvrdi')!.trigger('click')
+    await flushPromises()
+
+    await wrapper.findAll('button').find(b => b.text() === 'Novo plaćanje')!.trigger('click')
+    expect(wrapper.text()).toContain('Plati')
+  })
+
+  // Section 5: Recipients
+  it('renders Primaoci section with top recipients', async () => {
+    const wrapper = mount(ClientDashboardView)
+    await flushPromises()
+    expect(wrapper.text()).toContain('Primaoci')
+    const items = wrapper.findAll('.recipient-item')
+    expect(items).toHaveLength(2)
+    expect(wrapper.text()).toContain('EPS')
+    expect(wrapper.text()).toContain('Telenor')
+  })
+
+  // Section 6: Notifications
+  it('renders Obaveštenja section', async () => {
+    const wrapper = mount(ClientDashboardView)
+    await flushPromises()
+    expect(wrapper.text()).toContain('Obaveštenja')
+  })
+
+  it('shows notification items derived from recent activity', async () => {
+    const wrapper = mount(ClientDashboardView)
+    await flushPromises()
+    const items = wrapper.findAll('.notification-item')
+    expect(items.length).toBeGreaterThan(0)
+  })
+
+  it('loads all data on mount', async () => {
+    mount(ClientDashboardView)
+    await flushPromises()
+    expect(clientAccountApi.listByClient).toHaveBeenCalledWith('5')
+    expect(transferApi.listByClient).toHaveBeenCalled()
+    expect(paymentApi.listByClient).toHaveBeenCalled()
+    expect(exchangeApi.getRates).toHaveBeenCalled()
+    expect(recipientApi.listByClient).toHaveBeenCalledWith('5')
+  })
+})

--- a/src/views/client/ClientDashboardView.vue
+++ b/src/views/client/ClientDashboardView.vue
@@ -1,9 +1,337 @@
 <script setup lang="ts">
+import { ref, computed, onMounted } from 'vue'
+import { useClientAuthStore } from '../../stores/clientAuth'
+import { useClientAccountStore } from '../../stores/clientAccount'
+import { useTransferStore } from '../../stores/transfer'
+import { usePaymentStore } from '../../stores/payment'
+import { useRecipientStore } from '../../stores/recipient'
+import { exchangeApi, type ExchangeRate } from '../../api/exchange'
+import { paymentApi } from '../../api/payment'
+import type { PaymentItem } from '../../api/payment'
+
+const clientAuthStore = useClientAuthStore()
+const accountStore = useClientAccountStore()
+const transferStore = useTransferStore()
+const paymentStore = usePaymentStore()
+const recipientStore = useRecipientStore()
+
+const clientId = computed(() => String(clientAuthStore.client?.id ?? ''))
+
+// Section 3: Exchange rates
+const rates = ref<ExchangeRate[]>([])
+const loadingRates = ref(false)
+
+// Section 4: Quick payment inline flow
+const qpStep = ref<'form' | 'verify' | 'success'>('form')
+const qpForm = ref({ fromAccountId: '', recipientId: '', iznos: '', svrha: '' })
+const qpPayment = ref<PaymentItem | null>(null)
+const qpCode = ref('')
+const qpError = ref('')
+const qpLoading = ref(false)
+
+// Section 2: Recent activity — last 5 combined transfers + payments
+const recentActivity = computed(() => {
+  const items = [
+    ...transferStore.transfers.map(t => ({
+      type: 'transfer' as const,
+      id: t.id,
+      date: t.vremeTransakcije,
+      amount: t.iznos,
+      currency: t.valutaIznosa,
+      description: t.svrha || 'Transfer',
+      status: t.status,
+    })),
+    ...paymentStore.payments.map(p => ({
+      type: 'payment' as const,
+      id: p.id,
+      date: p.vremeTransakcije,
+      amount: p.iznos,
+      currency: '',
+      description: p.svrha || 'Plaćanje',
+      status: p.status,
+    })),
+  ]
+  return items
+    .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
+    .slice(0, 5)
+})
+
+// Section 5: Top recipients (up to 5)
+const topRecipients = computed(() => recipientStore.recipients.slice(0, 5))
+
+// Section 6: Notifications derived from recent activity
+const notifications = computed(() =>
+  recentActivity.value.slice(0, 3).map(a => ({
+    id: `${a.type}-${a.id}`,
+    text: `${a.type === 'transfer' ? 'Transfer' : 'Plaćanje'}: ${a.description} — ${a.amount.toLocaleString('sr-RS')} ${a.currency}`,
+    status: a.status,
+    date: a.date,
+  }))
+)
+
+function statusBadgeClass(status: string) {
+  switch (status) {
+    case 'uspesno':    return 'badge-success'
+    case 'neuspesno':  return 'badge-error'
+    case 'u_obradi':   return 'badge-warning'
+    case 'stornirano': return 'badge-neutral'
+    default:           return 'badge-neutral'
+  }
+}
+
+async function loadRates() {
+  loadingRates.value = true
+  try {
+    const res = await exchangeApi.getRates()
+    rates.value = (res.data.rates ?? []).slice(0, 5)
+  } catch {
+    rates.value = []
+  } finally {
+    loadingRates.value = false
+  }
+}
+
+async function qpSubmit() {
+  qpError.value = ''
+  if (!qpForm.value.fromAccountId) { qpError.value = 'Izaberite račun.'; return }
+  if (!qpForm.value.recipientId)   { qpError.value = 'Izaberite primaoca.'; return }
+  if (!qpForm.value.iznos || Number(qpForm.value.iznos) <= 0) { qpError.value = 'Unesite iznos.'; return }
+  qpLoading.value = true
+  try {
+    const recipient = recipientStore.recipients.find(r => r.id === qpForm.value.recipientId)
+    const res = await paymentApi.create({
+      racunPosiljaocaId: Number(qpForm.value.fromAccountId),
+      racunPrimaocaBroj: recipient!.brojRacuna,
+      iznos: Number(qpForm.value.iznos),
+      sifraPlacanja: '289',
+      pozivNaBroj: '',
+      svrha: qpForm.value.svrha || 'Brzo plaćanje',
+      recipientId: Number(qpForm.value.recipientId),
+    })
+    qpPayment.value = res.data.payment
+    qpStep.value = 'verify'
+  } catch (e: any) {
+    qpError.value = e.response?.data?.message || 'Greška pri plaćanju.'
+  } finally {
+    qpLoading.value = false
+  }
+}
+
+async function qpVerify() {
+  if (!qpCode.value || qpCode.value.length !== 6) {
+    qpError.value = 'Unesite 6-cifreni kod.'
+    return
+  }
+  qpLoading.value = true
+  qpError.value = ''
+  try {
+    await paymentApi.verify(qpPayment.value!.id, qpCode.value)
+    qpStep.value = 'success'
+    await paymentStore.fetchByClient(clientId.value)
+  } catch (e: any) {
+    qpError.value = e.response?.data?.message || 'Neispravan kod.'
+  } finally {
+    qpLoading.value = false
+  }
+}
+
+function qpReset() {
+  qpForm.value = { fromAccountId: '', recipientId: '', iznos: '', svrha: '' }
+  qpCode.value = ''
+  qpError.value = ''
+  qpPayment.value = null
+  qpStep.value = 'form'
+}
+
+onMounted(async () => {
+  if (!clientId.value) return
+  await Promise.all([
+    accountStore.fetchAccounts(clientId.value),
+    transferStore.fetchByClient(clientId.value),
+    paymentStore.fetchByClient(clientId.value),
+    recipientStore.fetchRecipients(clientId.value),
+    loadRates(),
+  ])
+})
 </script>
 
 <template>
   <div class="page-container">
-    <h1>ClientDashboardView</h1>
-    <p>Coming soon</p>
+    <h1 class="page-title">Dobrodošli, {{ clientAuthStore.client?.ime }}!</h1>
+
+    <!-- Section 1: Računi -->
+    <section class="dashboard-section">
+      <h2 class="section-title">Moji računi</h2>
+      <div v-if="accountStore.loading" class="loading-msg">Učitavam račune...</div>
+      <div v-else-if="accountStore.accounts.length === 0" class="empty-msg">Nemate račune.</div>
+      <div v-else class="accounts-grid">
+        <div
+          v-for="acc in accountStore.accounts"
+          :key="acc.id"
+          class="account-summary-card"
+        >
+          <div class="account-name">{{ acc.naziv || acc.brojRacuna }}</div>
+          <div class="account-currency">{{ acc.currencyKod }}</div>
+          <div class="account-balance">{{ acc.stanje.toLocaleString('sr-RS') }}</div>
+          <div class="account-available">Raspoloživo: {{ acc.raspolozivoStanje.toLocaleString('sr-RS') }}</div>
+        </div>
+      </div>
+    </section>
+
+    <div class="dashboard-two-col">
+
+      <!-- Section 2: Poslednje transakcije -->
+      <section class="dashboard-section">
+        <h2 class="section-title">Poslednje transakcije</h2>
+        <div v-if="recentActivity.length === 0" class="empty-msg">Nema transakcija.</div>
+        <table v-else class="data-table">
+          <thead>
+            <tr>
+              <th>Opis</th>
+              <th>Iznos</th>
+              <th>Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="item in recentActivity" :key="item.id + item.type" class="activity-row">
+              <td>{{ item.description }}</td>
+              <td>{{ item.amount.toLocaleString('sr-RS') }} {{ item.currency }}</td>
+              <td><span :class="['badge', statusBadgeClass(item.status)]">{{ item.status }}</span></td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
+      <!-- Section 3: Kursna lista -->
+      <section class="dashboard-section">
+        <h2 class="section-title">Kursna lista</h2>
+        <div v-if="loadingRates" class="loading-msg">Učitavam...</div>
+        <div v-else-if="rates.length === 0" class="empty-msg">Kursevi nisu dostupni.</div>
+        <table v-else class="data-table">
+          <thead>
+            <tr>
+              <th>Valuta</th>
+              <th>Kurs (RSD)</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="r in rates" :key="`${r.from}-${r.to}`" class="rate-row">
+              <td>{{ r.from }}/{{ r.to }}</td>
+              <td>{{ r.rate.toFixed(4) }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
+    </div>
+
+    <div class="dashboard-two-col">
+
+      <!-- Section 4: Brzo plaćanje -->
+      <section class="dashboard-section">
+        <h2 class="section-title">Brzo plaćanje</h2>
+
+        <!-- Form step -->
+        <div v-if="qpStep === 'form'">
+          <div class="form-group">
+            <label>Sa računa</label>
+            <select v-model="qpForm.fromAccountId" class="form-input">
+              <option value="">-- Račun --</option>
+              <option v-for="acc in accountStore.accounts" :key="acc.id" :value="String(acc.id)">
+                {{ acc.naziv || acc.brojRacuna }} ({{ acc.currencyKod }})
+              </option>
+            </select>
+          </div>
+          <div class="form-group">
+            <label>Primalac</label>
+            <select v-model="qpForm.recipientId" class="form-input">
+              <option value="">-- Primalac --</option>
+              <option v-for="r in recipientStore.recipients" :key="r.id" :value="r.id">
+                {{ r.naziv }}
+              </option>
+            </select>
+          </div>
+          <div class="form-group">
+            <label>Iznos</label>
+            <input v-model="qpForm.iznos" type="number" min="0.01" step="0.01" class="form-input" placeholder="0.00" />
+          </div>
+          <div class="form-group">
+            <label>Svrha</label>
+            <input v-model="qpForm.svrha" type="text" class="form-input" placeholder="Brzo plaćanje" />
+          </div>
+          <div v-if="qpError" class="error-message">{{ qpError }}</div>
+          <button class="btn btn-primary" :disabled="qpLoading" @click="qpSubmit">
+            {{ qpLoading ? 'Šaljem...' : 'Plati' }}
+          </button>
+        </div>
+
+        <!-- Verify step -->
+        <div v-else-if="qpStep === 'verify'">
+          <p class="text-muted">Unesite 6-cifreni verifikacioni kod.</p>
+          <div class="form-group">
+            <input
+              v-model="qpCode"
+              type="text"
+              maxlength="6"
+              class="form-input"
+              placeholder="------"
+            />
+          </div>
+          <div v-if="qpError" class="error-message">{{ qpError }}</div>
+          <div class="action-row">
+            <button class="btn btn-secondary" @click="qpStep = 'form'">Nazad</button>
+            <button
+              class="btn btn-primary"
+              :disabled="qpCode.length !== 6 || qpLoading"
+              @click="qpVerify"
+            >
+              Potvrdi
+            </button>
+          </div>
+        </div>
+
+        <!-- Success step -->
+        <div v-else class="success-box">
+          <div class="success-icon">✓</div>
+          <p>Plaćanje uspešno!</p>
+          <button class="btn btn-primary" @click="qpReset">Novo plaćanje</button>
+        </div>
+      </section>
+
+      <!-- Section 5: Primaoci -->
+      <section class="dashboard-section">
+        <h2 class="section-title">Primaoci</h2>
+        <div v-if="topRecipients.length === 0" class="empty-msg">Nema sačuvanih primalaca.</div>
+        <ul v-else class="recipients-list">
+          <li
+            v-for="r in topRecipients"
+            :key="r.id"
+            class="recipient-item"
+          >
+            <span class="recipient-name">{{ r.naziv }}</span>
+            <span class="recipient-account">{{ r.brojRacuna }}</span>
+          </li>
+        </ul>
+      </section>
+
+    </div>
+
+    <!-- Section 6: Obaveštenja -->
+    <section class="dashboard-section">
+      <h2 class="section-title">Obaveštenja</h2>
+      <div v-if="notifications.length === 0" class="empty-msg">Nema obaveštenja.</div>
+      <ul v-else class="notifications-list">
+        <li
+          v-for="n in notifications"
+          :key="n.id"
+          class="notification-item"
+        >
+          <span :class="['badge', statusBadgeClass(n.status)]">{{ n.status }}</span>
+          <span class="notification-text">{{ n.text }}</span>
+          <span class="notification-date">{{ new Date(n.date).toLocaleDateString('sr-RS') }}</span>
+        </li>
+      </ul>
+    </section>
+
   </div>
 </template>


### PR DESCRIPTION
Implements Issue #18 (DASHBOARD-FE-1):

- Section 1: Moji računi — balance cards for each client account
- Section 2: Poslednje transakcije — combined transfers + payments, last 5 sorted by date
- Section 3: Kursna lista — mini exchange rate table
- Section 4: Brzo plaćanje — real inline 3-step flow (form → verify 6-digit code → success)
- Section 5: Primaoci — top 5 saved recipients
- Section 6: Obaveštenja — recent activity notifications
- 18 view tests, all 176 tests passing across 19 test files

Fixes #18