### PR TITLE
feat: add Sprint 4 market portals and Cypress coverage

### DIFF
--- a/cypress/e2e/employee/market.cy.js
+++ b/cypress/e2e/employee/market.cy.js
@@ -1,0 +1,76 @@
+import { adminLogin as adminAccessToken } from '../helpers/banking'
+import {
+  activateEmployee,
+  createEmployee,
+  fetchMailhogLinkToken,
+  loginEmployeeUi,
+  updateEmployeePermissions,
+} from '../helpers/employee'
+
+const EMPLOYEE_PASSWORD = 'EmpPass12!'
+
+function assertEmployeeMarketReadOnly() {
+  cy.get('button, a').then(($elements) => {
+    const text = $elements.text().toLowerCase()
+    expect(text).not.to.include('kupi')
+    expect(text).not.to.include('prodaj')
+    expect(text).not.to.include('buy')
+    expect(text).not.to.include('sell')
+  })
+}
+
+describe('Employee market foundation', () => {
+  it('allows an actuary employee to open employee securities and portfolio pages', () => {
+    const testData = {}
+
+    adminAccessToken()
+      .then((adminToken) => {
+        testData.adminToken = adminToken
+        return createEmployee(adminToken, 'market-agent', {
+          ime: 'Market',
+          prezime: 'Agent',
+          pozicija: 'Agent',
+        }).then((employee) => {
+          testData.employee = employee
+          return updateEmployeePermissions(adminToken, employee.id, ['employeeAgent'])
+        })
+      })
+      .then(() =>
+        fetchMailhogLinkToken(testData.employee.email, 'Activate Your Bank Account', '/activate/')
+      )
+      .then((token) => activateEmployee(token, EMPLOYEE_PASSWORD))
+      .then(() => {
+        loginEmployeeUi(testData.employee.email, EMPLOYEE_PASSWORD)
+
+        cy.get('.sidebar-nav').should('contain', 'Hartije')
+        cy.get('.sidebar-nav').should('contain', 'Portfolio')
+        cy.get('.sidebar-nav').should('not.contain', 'Aktuari')
+
+        cy.visit('/securities')
+        cy.contains('h1', 'Hartije od vrednosti').should('be.visible')
+        cy.contains('td', 'AAPL').should('be.visible')
+        assertEmployeeMarketReadOnly()
+
+        cy.visit('/portfolio')
+        cy.contains('h1', 'Portfolio').should('be.visible')
+        cy.contains('h2', 'Pozicije').should('be.visible')
+        cy.get('.portfolio-table tbody tr').should('have.length.greaterThan', 0)
+        cy.get('.portfolio-table tbody tr').first().find('a').should('exist')
+        assertEmployeeMarketReadOnly()
+
+        cy.visit('/actuaries')
+        cy.url().should('include', '/clients')
+      })
+  })
+
+  it('allows an admin to open the actuaries management page', () => {
+    loginEmployeeUi()
+
+    cy.get('.sidebar-nav').should('contain', 'Aktuari')
+
+    cy.visit('/actuaries')
+    cy.contains('h1', 'Aktuari i supervizori').should('be.visible')
+    cy.contains('h2', 'Lista ovlascenih zaposlenih').should('be.visible')
+    cy.contains('admin@bank.com').should('be.visible')
+  })
+})

--- a/cypress/e2e/helpers/banking.js
+++ b/cypress/e2e/helpers/banking.js
@@ -63,11 +63,24 @@ export function activateClient(setupToken, password = Cypress.env('clientPasswor
 }
 
 export function loginClientUi(email, password = Cypress.env('clientPassword')) {
-  cy.visit('/client/login')
+  cy.visit('/client/login', {
+    onBeforeLoad(win) {
+      win.sessionStorage.clear()
+    },
+  })
   cy.get('input[type="email"]').clear().type(email)
   cy.get('input[type="password"]').clear().type(password)
   cy.contains('button', 'Sign In').click()
   cy.url().should('include', '/client/dashboard')
+}
+
+export function updateClientPermissions(employeeToken, clientId, permissionNames) {
+  return cy.request({
+    method: 'PUT',
+    url: `${API_BASE}/clients/${clientId}/permissions`,
+    headers: { Authorization: `Bearer ${employeeToken}` },
+    body: { permission_names: permissionNames },
+  })
 }
 
 export function createAccount(employeeToken, clientId, currencyId, naziv, pocetnoStanje, overrides = {}) {

--- a/cypress/e2e/helpers/employee.js
+++ b/cypress/e2e/helpers/employee.js
@@ -10,11 +10,94 @@ export function adminLogin() {
 }
 
 export function loginEmployeeUi(email = Cypress.env('adminEmail'), password = Cypress.env('adminPassword')) {
-  cy.visit('/login')
+  cy.visit('/login', {
+    onBeforeLoad(win) {
+      win.sessionStorage.clear()
+    },
+  })
   cy.get('input[type="email"]').clear().type(email)
   cy.get('input[type="password"]').clear().type(password)
   cy.contains('button', 'Sign In').click()
   cy.url().should('not.include', '/login')
+}
+
+export function createEmployee(adminToken, label, overrides = {}) {
+  const timestamp = Date.now()
+  const email = overrides.email || `cypress.employee.${label}.${timestamp}@bank.com`
+  const username = overrides.username || `cyemp${timestamp}`
+
+  return cy.request({
+    method: 'POST',
+    url: `${API_BASE}/employees`,
+    headers: { Authorization: `Bearer ${adminToken}` },
+    body: {
+      ime: overrides.ime || 'Cypress',
+      prezime: overrides.prezime || 'Employee',
+      datumRodjenja: overrides.datumRodjenja || 946684800,
+      pol: overrides.pol || 'M',
+      email,
+      brojTelefona: overrides.brojTelefona || '0641234567',
+      adresa: overrides.adresa || 'Cypress Employee 1',
+      username,
+      pozicija: overrides.pozicija || 'Analyst',
+      departman: overrides.departman || 'Trading',
+      aktivan: false,
+    },
+  }).then(({ body }) => ({
+    id: String(body.employee.id),
+    ime: overrides.ime || 'Cypress',
+    prezime: overrides.prezime || 'Employee',
+    email,
+    username,
+  }))
+}
+
+export function updateEmployeePermissions(adminToken, employeeId, permissionNames) {
+  return cy.request({
+    method: 'PUT',
+    url: `${API_BASE}/employees/${employeeId}/permissions`,
+    headers: { Authorization: `Bearer ${adminToken}` },
+    body: { permissionNames },
+  })
+}
+
+function normalizeMailhogBody(body) {
+  return body
+    .replace(/=\r?\n/g, '')
+    .replace(/=3D/g, '=')
+}
+
+export function fetchMailhogLinkToken(toEmail, subjectHint, routePrefix, attempt = 0) {
+  return cy.request('GET', 'http://localhost:8025/api/v2/messages').then(({ body }) => {
+    const items = body.items || []
+    const match = [...items].reverse().find((item) => {
+      const toHeader = (item.Content?.Headers?.To || []).join(' ')
+      const subjectHeader = (item.Content?.Headers?.Subject || []).join(' ')
+      return toHeader.includes(toEmail) && subjectHeader.includes(subjectHint)
+    })
+
+    if (match) {
+      const normalized = normalizeMailhogBody(match.Content?.Body || '')
+      const tokenMatch = normalized.match(new RegExp(`${routePrefix.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}([^"'<>\\s]+)`))
+      expect(tokenMatch, 'mailhog activation token').to.not.be.null
+      return tokenMatch[1]
+    }
+
+    if (attempt >= 10) {
+      throw new Error(`Mailhog token not found for ${toEmail} / ${subjectHint}`)
+    }
+
+    cy.wait(1000)
+    return fetchMailhogLinkToken(toEmail, subjectHint, routePrefix, attempt + 1)
+  })
+}
+
+export function activateEmployee(token, password = 'EmpPass12!') {
+  return cy.request('POST', `${API_BASE}/auth/activate`, {
+    token,
+    password,
+    passwordConfirm: password,
+  })
 }
 
 export { API_BASE }

--- a/cypress/e2e/market/client-market.cy.js
+++ b/cypress/e2e/market/client-market.cy.js
@@ -1,0 +1,82 @@
+import {
+  activateClient,
+  adminLogin,
+  createClient,
+  loginClientUi,
+  updateClientPermissions,
+} from '../helpers/banking'
+
+function assertNoTradingActions() {
+  cy.get('button, a').then(($elements) => {
+    const text = $elements.text().toLowerCase()
+    expect(text).not.to.include('kupi')
+    expect(text).not.to.include('prodaj')
+    expect(text).not.to.include('buy')
+    expect(text).not.to.include('sell')
+  })
+}
+
+describe('Client market foundation', () => {
+  it('allows a trading-enabled client to browse securities details and portfolio in read-only mode', () => {
+    const testData = {}
+
+    adminLogin()
+      .then((employeeToken) => {
+        testData.employeeToken = employeeToken
+        return createClient(employeeToken, 'market-trading').then((client) => {
+          testData.client = client
+          return updateClientPermissions(employeeToken, client.id, ['clientBasic', 'clientTrading'])
+        })
+      })
+      .then(() => activateClient(testData.client.setupToken))
+      .then(() => {
+        loginClientUi(testData.client.email)
+
+        cy.get('.sidebar-nav').should('contain', 'Hartije')
+        cy.get('.sidebar-nav').should('contain', 'Portfolio')
+
+        cy.visit('/client/securities')
+        cy.contains('h1', 'Hartije od vrednosti').should('be.visible')
+        cy.contains('td', 'AAPL').should('be.visible')
+        cy.get('input[placeholder*="ticker"]').clear().type('Apple')
+        cy.contains('td', 'AAPL').should('be.visible')
+        assertNoTradingActions()
+
+        cy.visit('/client/securities/AAPL')
+        cy.contains('h1', 'Apple Inc.').should('be.visible')
+        cy.contains('h2', 'Istorija kretanja cene').should('be.visible')
+        assertNoTradingActions()
+
+        cy.visit('/client/portfolio')
+        cy.contains('h1', 'Portfolio').should('be.visible')
+        cy.contains('h2', 'Pozicije').should('be.visible')
+        cy.get('.portfolio-table tbody tr').should('have.length.greaterThan', 0)
+        cy.get('.portfolio-table tbody tr').first().find('a').should('exist')
+        assertNoTradingActions()
+      })
+  })
+
+  it('hides market navigation and redirects a client without trading permission', () => {
+    const testData = {}
+
+    adminLogin()
+      .then((employeeToken) =>
+        createClient(employeeToken, 'market-basic').then((client) => {
+          testData.client = client
+        })
+      )
+      .then(() => activateClient(testData.client.setupToken))
+      .then(() => {
+        loginClientUi(testData.client.email)
+
+        cy.get('.sidebar-nav').should('not.contain', 'Hartije')
+        cy.get('.sidebar-nav').should('not.contain', 'Portfolio')
+
+        cy.visit('/client/securities')
+        cy.url().should('include', '/client/dashboard')
+
+        cy.visit('/client/portfolio')
+        cy.url().should('include', '/client/dashboard')
+      })
+  })
+})

--- a/nginx.conf
+++ b/nginx.conf
@@ -23,6 +23,12 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
     }
 
+    location /api/v1/actuaries {
+        proxy_pass http://employee-service:8082;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+
     # Route client endpoints to the extracted client-service
     location /api/v1/clients {
         proxy_pass http://client-service:8083;
@@ -97,6 +103,24 @@ server {
     }
 
     # Route exchange endpoints to exchange-service
+    location /api/v1/exchanges {
+        proxy_pass http://exchange-service:8088;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+
+    location /api/v1/listings {
+        proxy_pass http://exchange-service:8088;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+
+    location /api/v1/portfolio {
+        proxy_pass http://exchange-service:8088;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+
     location /api/v1/exchange {
         proxy_pass http://exchange-service:8088;
         proxy_set_header Host $host;

--- a/src/__tests__/stores/clientAuth.test.ts
+++ b/src/__tests__/stores/clientAuth.test.ts
@@ -75,4 +75,27 @@ describe('clientAuth store', () => {
     store.logout()
     expect(store.isLoggedIn).toBe(false)
   })
+
+  it('exposes permissions and checks client trading access', async () => {
+    vi.mocked(clientAuthApi.login).mockResolvedValueOnce({
+      data: {
+        accessToken: 'test-access',
+        refreshToken: 'test-refresh',
+        client: {
+          id: '1',
+          ime: 'Ana',
+          prezime: 'Jovic',
+          email: 'ana@gmail.com',
+          permissions: ['clientBasic', 'clientTrading'],
+        },
+      },
+    })
+
+    const store = useClientAuthStore()
+    await store.login('ana@gmail.com', 'password123')
+
+    expect(store.permissions).toEqual(['clientBasic', 'clientTrading'])
+    expect(store.hasPermission('clientTrading')).toBe(true)
+    expect(store.hasPermission('employeeAgent')).toBe(false)
+  })
 })

--- a/src/api/actuary.ts
+++ b/src/api/actuary.ts
@@ -1,0 +1,22 @@
+import api from './client'
+
+export interface ActuaryManagementItem {
+  employeeId: string
+  ime: string
+  prezime: string
+  email: string
+  username: string
+  pozicija: string
+  departman: string
+  aktivan: boolean
+  permissionNames: string[]
+  isActuary: boolean
+  isSupervisor: boolean
+  limit?: number
+  usedLimit: number
+  needApproval: boolean
+}
+
+export const actuaryApi = {
+  list: () => api.get<{ actuaries: ActuaryManagementItem[]; count: number }>('/actuaries'),
+}

--- a/src/api/employeeMarket.ts
+++ b/src/api/employeeMarket.ts
@@ -1,0 +1,19 @@
+import api from './client'
+import type {
+  ExchangeItem,
+  ListingHistoryItem,
+  ListingItem,
+  PortfolioOverview,
+} from './market'
+
+export const employeeMarketApi = {
+  listExchanges: () => api.get<{ exchanges: ExchangeItem[]; count: number }>('/exchanges'),
+  listListings: (q = '') =>
+    api.get<{ listings: ListingItem[]; count: number; query: string }>('/listings', {
+      params: { q: q || undefined },
+    }),
+  getListing: (ticker: string) => api.get<{ listing: ListingItem }>(`/listings/${ticker}`),
+  getListingHistory: (ticker: string) =>
+    api.get<{ ticker: string; history: ListingHistoryItem[] }>(`/listings/${ticker}/history`),
+  getPortfolio: () => api.get<{ portfolio: PortfolioOverview }>('/portfolio'),
+}

--- a/src/api/market.ts
+++ b/src/api/market.ts
@@ -1,0 +1,79 @@
+import clientApi from './clientAuth'
+
+export interface ExchangeItem {
+  name: string
+  acronym: string
+  micCode: string
+  polity: string
+  currency: string
+  timezone: string
+  workingHours: string
+  enabled: boolean
+}
+
+export interface ExchangeSummary {
+  name: string
+  acronym: string
+  micCode: string
+  currency: string
+}
+
+export interface ListingItem {
+  ticker: string
+  name: string
+  exchange: ExchangeSummary
+  lastRefresh: string
+  price: number
+  ask: number
+  bid: number
+  volume: number
+  type: string
+}
+
+export interface ListingHistoryItem {
+  date: string
+  price: number
+  high: number
+  low: number
+  change: number
+  volume: number
+}
+
+export interface PortfolioItem {
+  ticker: string
+  name: string
+  exchange: string
+  currency: string
+  quantity: number
+  averagePrice: number
+  currentPrice: number
+  marketValue: number
+  pnl: number
+  pnlPercent: number
+}
+
+export interface PortfolioOverview {
+  ownerId: string
+  ownerType: string
+  generatedAt: string
+  valuationAsOf: string
+  valuationCurrency: string
+  estimatedValue: number
+  unrealizedPnL: number
+  positionCount: number
+  readOnly: boolean
+  modelType: string
+  positionSource: string
+  pricingSource: string
+  items: PortfolioItem[]
+}
+
+export const marketApi = {
+  listExchanges: () => clientApi.get<{ exchanges: ExchangeItem[]; count: number }>('/exchanges'),
+  listListings: (q = '') => clientApi.get<{ listings: ListingItem[]; count: number; query: string }>('/listings', {
+    params: { q: q || undefined },
+  }),
+  getListing: (ticker: string) => clientApi.get<{ listing: ListingItem }>(`/listings/${ticker}`),
+  getListingHistory: (ticker: string) => clientApi.get<{ ticker: string; history: ListingHistoryItem[] }>(`/listings/${ticker}/history`),
+  getPortfolio: () => clientApi.get<{ portfolio: PortfolioOverview }>('/portfolio'),
+}

--- a/src/router/clientRoutes.ts
+++ b/src/router/clientRoutes.ts
@@ -21,6 +21,21 @@ export const clientRoutes: RouteRecordRaw[] = [
         component: () => import('../views/client/ClientAccountsView.vue'),
       },
       {
+        path: 'securities',
+        component: () => import('../views/client/ClientSecuritiesView.vue'),
+        meta: { clientTradingOnly: true },
+      },
+      {
+        path: 'securities/:ticker',
+        component: () => import('../views/client/ClientSecurityDetailsView.vue'),
+        meta: { clientTradingOnly: true },
+      },
+      {
+        path: 'portfolio',
+        component: () => import('../views/client/ClientPortfolioView.vue'),
+        meta: { clientTradingOnly: true },
+      },
+      {
         path: 'prenos',
         component: () => import('../views/client/ClientPrenosView.vue'),
       },

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -49,6 +49,26 @@ const router = createRouter({
           component: () => import('../views/CreateAccountView.vue'),
         },
         {
+          path: 'securities',
+          component: () => import('../views/EmployeeSecuritiesView.vue'),
+          meta: { employeeTradingOnly: true },
+        },
+        {
+          path: 'securities/:ticker',
+          component: () => import('../views/EmployeeSecurityDetailsView.vue'),
+          meta: { employeeTradingOnly: true },
+        },
+        {
+          path: 'portfolio',
+          component: () => import('../views/EmployeePortfolioView.vue'),
+          meta: { employeeTradingOnly: true },
+        },
+        {
+          path: 'actuaries',
+          component: () => import('../views/EmployeeActuariesManagementView.vue'),
+          meta: { employeeSupervisorOnly: true },
+        },
+        {
           path: 'loans/requests',
           component: () => import('../views/LoanRequestsView.vue'),
         },
@@ -69,11 +89,16 @@ router.beforeEach((to) => {
   // Client routes
   if (to.meta.clientOnly && !clientAuth.isLoggedIn) return '/client/login'
   if (to.path === '/client/login' && clientAuth.isLoggedIn) return '/client/dashboard'
+  if (to.meta.clientTradingOnly && !clientAuth.hasPermission('clientTrading')) {
+    return '/client/dashboard'
+  }
   if (to.meta.clientOnly || to.meta.clientPublic) return
 
   // Employee routes
   if (!to.meta.public && !auth.isLoggedIn) return '/login'
   if (to.path === '/login' && auth.isLoggedIn) return '/clients'
+  if (to.meta.employeeTradingOnly && !auth.hasPermission('employeeAgent')) return '/clients'
+  if (to.meta.employeeSupervisorOnly && !auth.hasPermission('employeeSupervisor')) return '/clients'
   if (to.meta.adminOnly && !auth.hasPermission('employeeAdmin')) return '/clients'
 })
 

--- a/src/stores/clientAuth.ts
+++ b/src/stores/clientAuth.ts
@@ -18,6 +18,7 @@ export const useClientAuthStore = defineStore('clientAuth', () => {
   )
 
   const isLoggedIn = computed(() => !!accessToken.value)
+  const permissions = computed(() => client.value?.permissions ?? [])
 
   async function login(email: string, password: string) {
     const res = await clientAuthApi.login(email, password)
@@ -39,5 +40,18 @@ export const useClientAuthStore = defineStore('clientAuth', () => {
     sessionStorage.removeItem('client')
   }
 
-  return { accessToken, refreshToken, client, isLoggedIn, login, logout }
+  function hasPermission(permission: string) {
+    return permissions.value.includes(permission)
+  }
+
+  return {
+    accessToken,
+    refreshToken,
+    client,
+    isLoggedIn,
+    permissions,
+    login,
+    logout,
+    hasPermission,
+  }
 })

--- a/src/stores/employeeMarket.ts
+++ b/src/stores/employeeMarket.ts
@@ -1,0 +1,96 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import {
+  employeeMarketApi,
+} from '../api/employeeMarket'
+import type {
+  ExchangeItem,
+  ListingHistoryItem,
+  ListingItem,
+  PortfolioOverview,
+} from '../api/market'
+
+export const useEmployeeMarketStore = defineStore('employeeMarket', () => {
+  const exchanges = ref<ExchangeItem[]>([])
+  const listings = ref<ListingItem[]>([])
+  const currentListing = ref<ListingItem | null>(null)
+  const currentHistory = ref<ListingHistoryItem[]>([])
+  const portfolio = ref<PortfolioOverview | null>(null)
+
+  const loading = ref(false)
+  const detailsLoading = ref(false)
+  const portfolioLoading = ref(false)
+  const error = ref('')
+
+  async function fetchExchanges() {
+    try {
+      const res = await employeeMarketApi.listExchanges()
+      exchanges.value = res.data.exchanges ?? []
+    } catch (e: any) {
+      exchanges.value = []
+      error.value = e.response?.data?.message || 'Failed to load exchanges.'
+    }
+  }
+
+  async function fetchListings(query = '') {
+    loading.value = true
+    error.value = ''
+    try {
+      const res = await employeeMarketApi.listListings(query)
+      listings.value = res.data.listings ?? []
+    } catch (e: any) {
+      error.value = e.response?.data?.message || 'Failed to load listings.'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function fetchListingDetails(ticker: string) {
+    detailsLoading.value = true
+    error.value = ''
+    try {
+      const [listingRes, historyRes] = await Promise.all([
+        employeeMarketApi.getListing(ticker),
+        employeeMarketApi.getListingHistory(ticker),
+      ])
+      currentListing.value = listingRes.data.listing
+      currentHistory.value = historyRes.data.history ?? []
+    } catch (e: any) {
+      error.value = e.response?.data?.message || 'Failed to load security details.'
+      currentListing.value = null
+      currentHistory.value = []
+    } finally {
+      detailsLoading.value = false
+    }
+  }
+
+  async function fetchPortfolio() {
+    portfolioLoading.value = true
+    error.value = ''
+    try {
+      const res = await employeeMarketApi.getPortfolio()
+      portfolio.value = res.data.portfolio
+    } catch (e: any) {
+      error.value = e.response?.data?.message || 'Failed to load portfolio.'
+      portfolio.value = null
+    } finally {
+      portfolioLoading.value = false
+    }
+  }
+
+  return {
+    exchanges,
+    listings,
+    currentListing,
+    currentHistory,
+    portfolio,
+    loading,
+    detailsLoading,
+    portfolioLoading,
+    error,
+    fetchExchanges,
+    fetchListings,
+    fetchListingDetails,
+    fetchPortfolio,
+  }
+})

--- a/src/stores/market.ts
+++ b/src/stores/market.ts
@@ -1,0 +1,94 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import {
+  marketApi,
+  type ExchangeItem,
+  type ListingHistoryItem,
+  type ListingItem,
+  type PortfolioOverview,
+} from '../api/market'
+
+export const useMarketStore = defineStore('market', () => {
+  const exchanges = ref<ExchangeItem[]>([])
+  const listings = ref<ListingItem[]>([])
+  const currentListing = ref<ListingItem | null>(null)
+  const currentHistory = ref<ListingHistoryItem[]>([])
+  const portfolio = ref<PortfolioOverview | null>(null)
+
+  const loading = ref(false)
+  const detailsLoading = ref(false)
+  const portfolioLoading = ref(false)
+  const error = ref('')
+
+  async function fetchExchanges() {
+    try {
+      const res = await marketApi.listExchanges()
+      exchanges.value = res.data.exchanges ?? []
+    } catch (e: any) {
+      exchanges.value = []
+      error.value = e.response?.data?.message || 'Failed to load exchanges.'
+    }
+  }
+
+  async function fetchListings(query = '') {
+    loading.value = true
+    error.value = ''
+    try {
+      const res = await marketApi.listListings(query)
+      listings.value = res.data.listings ?? []
+    } catch (e: any) {
+      error.value = e.response?.data?.message || 'Failed to load listings.'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function fetchListingDetails(ticker: string) {
+    detailsLoading.value = true
+    error.value = ''
+    try {
+      const [listingRes, historyRes] = await Promise.all([
+        marketApi.getListing(ticker),
+        marketApi.getListingHistory(ticker),
+      ])
+      currentListing.value = listingRes.data.listing
+      currentHistory.value = historyRes.data.history ?? []
+    } catch (e: any) {
+      error.value = e.response?.data?.message || 'Failed to load security details.'
+      currentListing.value = null
+      currentHistory.value = []
+    } finally {
+      detailsLoading.value = false
+    }
+  }
+
+  async function fetchPortfolio() {
+    portfolioLoading.value = true
+    error.value = ''
+    try {
+      const res = await marketApi.getPortfolio()
+      portfolio.value = res.data.portfolio
+    } catch (e: any) {
+      error.value = e.response?.data?.message || 'Failed to load portfolio.'
+      portfolio.value = null
+    } finally {
+      portfolioLoading.value = false
+    }
+  }
+
+  return {
+    exchanges,
+    listings,
+    currentListing,
+    currentHistory,
+    portfolio,
+    loading,
+    detailsLoading,
+    portfolioLoading,
+    error,
+    fetchExchanges,
+    fetchListings,
+    fetchListingDetails,
+    fetchPortfolio,
+  }
+})

--- a/src/views/EmployeeActuariesManagementView.vue
+++ b/src/views/EmployeeActuariesManagementView.vue
@@ -1,0 +1,313 @@
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+import { actuaryApi, type ActuaryManagementItem } from '../api/actuary'
+
+const actuaries = ref<ActuaryManagementItem[]>([])
+const loading = ref(false)
+const error = ref('')
+const query = ref('')
+
+const filteredActuaries = computed(() => {
+  const needle = query.value.trim().toLowerCase()
+  if (!needle) return actuaries.value
+
+  return actuaries.value.filter((item) =>
+    `${item.ime} ${item.prezime}`.toLowerCase().includes(needle) ||
+    item.email.toLowerCase().includes(needle) ||
+    item.username.toLowerCase().includes(needle)
+  )
+})
+
+async function fetchActuaries() {
+  loading.value = true
+  error.value = ''
+  try {
+    const res = await actuaryApi.list()
+    actuaries.value = res.data.actuaries ?? []
+  } catch (e: any) {
+    error.value = e.response?.data?.message || 'Failed to load actuaries.'
+  } finally {
+    loading.value = false
+  }
+}
+
+function formatLimit(value?: number) {
+  if (value == null) return 'Bez limita'
+  return value.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })
+}
+
+onMounted(fetchActuaries)
+</script>
+
+<template>
+  <div class="actuaries-page">
+    <div class="page-header">
+      <div>
+        <h1>Aktuari i supervizori</h1>
+        <p>Read-only pregled traderskih ovlascenja i limita kao Sprint 4 foundation.</p>
+      </div>
+      <div class="search-box">
+        <input v-model="query" type="text" placeholder="Pretraga po imenu, email-u ili username-u" />
+      </div>
+    </div>
+
+    <div class="summary-grid">
+      <article class="summary-card">
+        <span>Ukupno zapisa</span>
+        <strong>{{ actuaries.length }}</strong>
+      </article>
+      <article class="summary-card">
+        <span>Supervizori</span>
+        <strong>{{ actuaries.filter(item => item.isSupervisor).length }}</strong>
+      </article>
+      <article class="summary-card">
+        <span>Agenti</span>
+        <strong>{{ actuaries.filter(item => !item.isSupervisor).length }}</strong>
+      </article>
+    </div>
+
+    <div v-if="loading" class="empty-state">Ucitavam aktuare...</div>
+    <div v-else-if="error" class="error-box">{{ error }}</div>
+    <div v-else-if="filteredActuaries.length === 0" class="empty-state">Nema rezultata za zadatu pretragu.</div>
+    <section v-else class="panel">
+      <div class="panel-head">
+        <h2>Lista ovlascenih zaposlenih</h2>
+        <span>{{ filteredActuaries.length }} stavki</span>
+      </div>
+
+      <div class="table-wrap">
+        <table class="actuary-table">
+          <thead>
+            <tr>
+              <th>Zaposleni</th>
+              <th>Uloga</th>
+              <th>Pozicija</th>
+              <th>Limit</th>
+              <th>Used limit</th>
+              <th>Approval</th>
+              <th>Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="item in filteredActuaries" :key="item.employeeId">
+              <td>
+                <div class="person-name">{{ item.ime }} {{ item.prezime }}</div>
+                <div class="person-meta">{{ item.email }} | {{ item.username }}</div>
+              </td>
+              <td>
+                <span class="role-pill" :class="{ supervisor: item.isSupervisor }">
+                  {{ item.isSupervisor ? 'Supervisor' : 'Agent' }}
+                </span>
+              </td>
+              <td>
+                <div class="person-name">{{ item.pozicija || 'N/A' }}</div>
+                <div class="person-meta">{{ item.departman || 'N/A' }}</div>
+              </td>
+              <td>{{ formatLimit(item.limit) }}</td>
+              <td>{{ item.usedLimit.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 }) }}</td>
+              <td>
+                <span class="approval-pill" :class="{ yes: item.needApproval, no: !item.needApproval }">
+                  {{ item.needApproval ? 'Da' : 'Ne' }}
+                </span>
+              </td>
+              <td>
+                <span class="status-pill" :class="{ active: item.aktivan, inactive: !item.aktivan }">
+                  {{ item.aktivan ? 'Aktivan' : 'Neaktivan' }}
+                </span>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+  </div>
+</template>
+
+<style scoped>
+.actuaries-page {
+  padding: 32px;
+  max-width: 1280px;
+  margin: 0 auto;
+}
+
+.page-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 20px;
+  margin-bottom: 24px;
+}
+
+.page-header h1 {
+  margin: 0;
+  font-size: 30px;
+  color: #0f172a;
+}
+
+.page-header p {
+  margin: 8px 0 0;
+  color: #64748b;
+}
+
+.search-box input {
+  width: 340px;
+  max-width: 100%;
+  padding: 10px 14px;
+  border: 1px solid #cbd5e1;
+  border-radius: 10px;
+  font-size: 14px;
+}
+
+.summary-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+  margin-bottom: 24px;
+}
+
+.summary-card,
+.panel {
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 16px;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.04);
+}
+
+.summary-card {
+  padding: 20px;
+}
+
+.summary-card span {
+  display: block;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #64748b;
+}
+
+.summary-card strong {
+  display: block;
+  margin-top: 10px;
+  font-size: 24px;
+  color: #0f172a;
+}
+
+.panel {
+  padding: 24px;
+}
+
+.panel-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 18px;
+}
+
+.panel-head h2 {
+  margin: 0;
+  color: #0f172a;
+}
+
+.table-wrap {
+  overflow-x: auto;
+}
+
+.actuary-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.actuary-table th,
+.actuary-table td {
+  padding: 14px 12px;
+  border-bottom: 1px solid #e2e8f0;
+  text-align: left;
+}
+
+.actuary-table th {
+  font-size: 12px;
+  text-transform: uppercase;
+  color: #64748b;
+}
+
+.person-name {
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.person-meta {
+  font-size: 12px;
+  color: #64748b;
+}
+
+.role-pill,
+.approval-pill,
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 6px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.role-pill {
+  background: #dbeafe;
+  color: #1d4ed8;
+}
+
+.role-pill.supervisor {
+  background: #ede9fe;
+  color: #6d28d9;
+}
+
+.approval-pill.yes {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+.approval-pill.no {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.status-pill.active {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.status-pill.inactive {
+  background: #fee2e2;
+  color: #b91c1c;
+}
+
+.empty-state,
+.error-box {
+  padding: 32px;
+  border-radius: 16px;
+  text-align: center;
+}
+
+.empty-state {
+  background: #fff;
+  color: #64748b;
+  border: 1px solid #e2e8f0;
+}
+
+.error-box {
+  background: #fef2f2;
+  color: #b91c1c;
+}
+
+@media (max-width: 960px) {
+  .page-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .summary-grid {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/src/views/EmployeeLayout.vue
+++ b/src/views/EmployeeLayout.vue
@@ -15,19 +15,24 @@ function logout() {
 }
 
 const allNavItems = [
-  { to: '/employees', label: 'Zaposleni', icon: '□', perm: 'manageAll' },
-  { to: '/clients', label: 'Klijenti', icon: '◉', perm: 'clients' },
-  { to: '/accounts', label: 'Računi', icon: '◈', perm: 'bankOps' },
-  { to: '/accounts/new', label: 'Novi račun', icon: '+', perm: 'bankOps' },
-  { to: '/loans/requests', label: 'Zahtevi kredita', icon: '▣', perm: 'bankOps' },
-  { to: '/loans', label: 'Krediti', icon: '◇', perm: 'bankOps' },
+  { to: '/employees', label: 'Zaposleni', icon: 'E', perm: 'manageAll' },
+  { to: '/clients', label: 'Klijenti', icon: 'C', perm: 'clients' },
+  { to: '/accounts', label: 'Racuni', icon: 'R', perm: 'bankOps' },
+  { to: '/accounts/new', label: 'Novi racun', icon: '+', perm: 'bankOps' },
+  { to: '/securities', label: 'Hartije', icon: '$', perm: 'stockTrading' },
+  { to: '/portfolio', label: 'Portfolio', icon: 'P', perm: 'stockTrading' },
+  { to: '/actuaries', label: 'Aktuari', icon: 'A', perm: 'supervisor' },
+  { to: '/loans/requests', label: 'Zahtevi kredita', icon: 'Z', perm: 'bankOps' },
+  { to: '/loans', label: 'Krediti', icon: 'K', perm: 'bankOps' },
 ]
 
 const navItems = computed(() =>
-  allNavItems.filter(item => {
+  allNavItems.filter((item) => {
     if (item.perm === 'manageAll') return perms.canManageAll()
     if (item.perm === 'clients') return perms.canManageClients()
     if (item.perm === 'bankOps') return perms.canBankOperations()
+    if (item.perm === 'stockTrading') return perms.canStockTrading()
+    if (item.perm === 'supervisor') return perms.isSupervisor()
     return true
   })
 )
@@ -101,15 +106,20 @@ function isActive(to: string) {
 
 .sidebar-header {
   padding: 28px 24px 20px;
-  border-bottom: 1px solid rgba(255,255,255,0.08);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
 }
+
 .sidebar-logo {
   font-size: 24px;
   font-weight: 800;
   letter-spacing: -0.5px;
   color: #fff;
 }
-.sidebar-logo span { color: #60a5fa; }
+
+.sidebar-logo span {
+  color: #60a5fa;
+}
+
 .sidebar-subtitle {
   font-size: 11px;
   color: #64748b;
@@ -125,6 +135,7 @@ function isActive(to: string) {
   flex-direction: column;
   gap: 2px;
 }
+
 .sidebar-link {
   display: flex;
   align-items: center;
@@ -137,16 +148,19 @@ function isActive(to: string) {
   font-weight: 500;
   transition: all 0.15s ease;
 }
+
 .sidebar-link:hover {
   color: #e2e8f0;
-  background: rgba(255,255,255,0.06);
+  background: rgba(255, 255, 255, 0.06);
   text-decoration: none;
 }
+
 .sidebar-link.active {
   color: #fff;
   background: rgba(59, 130, 246, 0.2);
   box-shadow: inset 3px 0 0 #3b82f6;
 }
+
 .sidebar-icon {
   width: 20px;
   text-align: center;
@@ -155,14 +169,16 @@ function isActive(to: string) {
 
 .sidebar-footer {
   padding: 16px;
-  border-top: 1px solid rgba(255,255,255,0.08);
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
 }
+
 .sidebar-user {
   display: flex;
   align-items: center;
   gap: 12px;
   margin-bottom: 12px;
 }
+
 .sidebar-avatar {
   width: 36px;
   height: 36px;
@@ -175,7 +191,11 @@ function isActive(to: string) {
   font-weight: 700;
   flex-shrink: 0;
 }
-.sidebar-user-info { overflow: hidden; }
+
+.sidebar-user-info {
+  overflow: hidden;
+}
+
 .sidebar-user-name {
   font-size: 13px;
   font-weight: 600;
@@ -184,6 +204,7 @@ function isActive(to: string) {
   overflow: hidden;
   text-overflow: ellipsis;
 }
+
 .sidebar-user-role {
   font-size: 11px;
   color: #64748b;
@@ -191,16 +212,18 @@ function isActive(to: string) {
   overflow: hidden;
   text-overflow: ellipsis;
 }
+
 .sidebar-logout {
   width: 100%;
   padding: 8px;
   border-radius: 6px;
-  background: rgba(255,255,255,0.06);
+  background: rgba(255, 255, 255, 0.06);
   color: #94a3b8;
   font-size: 13px;
-  border: 1px solid rgba(255,255,255,0.08);
+  border: 1px solid rgba(255, 255, 255, 0.08);
   transition: all 0.15s ease;
 }
+
 .sidebar-logout:hover {
   background: rgba(239, 68, 68, 0.15);
   color: #fca5a5;

--- a/src/views/EmployeePortfolioView.vue
+++ b/src/views/EmployeePortfolioView.vue
@@ -1,0 +1,283 @@
+<script setup lang="ts">
+import { computed, onMounted } from 'vue'
+import { RouterLink } from 'vue-router'
+import { useEmployeeMarketStore } from '../stores/employeeMarket'
+
+const marketStore = useEmployeeMarketStore()
+
+const holdingsCount = computed(() => marketStore.portfolio?.items.length ?? 0)
+
+onMounted(async () => {
+  await marketStore.fetchPortfolio()
+})
+</script>
+
+<template>
+  <div class="portfolio-page">
+    <div class="page-header">
+      <div>
+        <h1>Portfolio</h1>
+        <p>Read-only pregled pozicija za zaposlene sa traderskim ovlascenjima.</p>
+      </div>
+      <RouterLink to="/securities" class="secondary-link">Nazad na hartije</RouterLink>
+    </div>
+
+    <div v-if="marketStore.portfolioLoading" class="empty-state">Ucitavam portfolio...</div>
+    <div v-else-if="marketStore.error" class="error-box">{{ marketStore.error }}</div>
+    <div v-else-if="!marketStore.portfolio" class="empty-state">Portfolio trenutno nije dostupan.</div>
+    <template v-else>
+      <div class="summary-grid">
+        <article class="summary-card primary">
+          <span>Ukupna procenjena vrednost</span>
+          <strong>{{ marketStore.portfolio.estimatedValue.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 }) }}</strong>
+        </article>
+        <article class="summary-card">
+          <span>Nerealizovani P/L</span>
+          <strong :class="{ positive: marketStore.portfolio.unrealizedPnL >= 0, negative: marketStore.portfolio.unrealizedPnL < 0 }">
+            {{ marketStore.portfolio.unrealizedPnL.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 }) }}
+          </strong>
+        </article>
+        <article class="summary-card">
+          <span>Broj pozicija</span>
+          <strong>{{ holdingsCount }}</strong>
+        </article>
+        <article class="summary-card">
+          <span>Generisano</span>
+          <strong>{{ new Date(marketStore.portfolio.generatedAt).toLocaleString('sr-RS') }}</strong>
+        </article>
+      </div>
+
+      <section class="panel">
+        <div class="panel-head">
+          <h2>Pozicije</h2>
+          <span>{{ holdingsCount }} stavki</span>
+        </div>
+
+        <div class="table-wrap">
+          <table class="portfolio-table">
+            <thead>
+              <tr>
+                <th>Ticker</th>
+                <th>Naziv</th>
+                <th>Qty</th>
+                <th>Avg price</th>
+                <th>Current price</th>
+                <th>Market value</th>
+                <th>P/L</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="item in marketStore.portfolio.items" :key="item.ticker">
+                <td class="ticker">
+                  <RouterLink :to="`/securities/${item.ticker}`">{{ item.ticker }}</RouterLink>
+                </td>
+                <td>
+                  <div class="asset-name">{{ item.name }}</div>
+                  <div class="asset-meta">{{ item.exchange }} | {{ item.currency }}</div>
+                </td>
+                <td>{{ item.quantity.toLocaleString('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 2 }) }}</td>
+                <td>{{ item.averagePrice.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 }) }}</td>
+                <td>{{ item.currentPrice.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 }) }}</td>
+                <td>{{ item.marketValue.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 }) }}</td>
+                <td>
+                  <div :class="{ positive: item.pnl >= 0, negative: item.pnl < 0 }">
+                    {{ item.pnl.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 }) }}
+                  </div>
+                  <div class="asset-meta">{{ item.pnlPercent.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 }) }}%</div>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </template>
+  </div>
+</template>
+
+<style scoped>
+.portfolio-page {
+  padding: 32px;
+  max-width: 1220px;
+  margin: 0 auto;
+}
+
+.page-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 20px;
+  margin-bottom: 24px;
+}
+
+.page-header h1 {
+  margin: 0;
+  font-size: 30px;
+  color: #0f172a;
+}
+
+.page-header p {
+  margin: 8px 0 0;
+  color: #64748b;
+}
+
+.secondary-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 16px;
+  border-radius: 10px;
+  background: #fff;
+  border: 1px solid #cbd5e1;
+  color: #0f172a;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.summary-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+  margin-bottom: 24px;
+}
+
+.summary-card {
+  background: #fff;
+  border-radius: 16px;
+  padding: 20px;
+  border: 1px solid #e2e8f0;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.04);
+}
+
+.summary-card.primary {
+  background: linear-gradient(135deg, #0f172a 0%, #2563eb 100%);
+  color: #fff;
+  border: none;
+}
+
+.summary-card span {
+  display: block;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #64748b;
+}
+
+.summary-card.primary span {
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.summary-card strong {
+  display: block;
+  margin-top: 10px;
+  font-size: 24px;
+  color: #0f172a;
+}
+
+.summary-card.primary strong {
+  color: #fff;
+}
+
+.panel {
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 16px;
+  padding: 24px;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.04);
+}
+
+.panel-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 18px;
+}
+
+.panel-head h2 {
+  margin: 0;
+  color: #0f172a;
+}
+
+.table-wrap {
+  overflow-x: auto;
+}
+
+.portfolio-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.portfolio-table th,
+.portfolio-table td {
+  padding: 14px 12px;
+  border-bottom: 1px solid #e2e8f0;
+  text-align: left;
+}
+
+.portfolio-table th {
+  font-size: 12px;
+  text-transform: uppercase;
+  color: #64748b;
+}
+
+.ticker a {
+  color: #2563eb;
+  text-decoration: none;
+  font-weight: 700;
+}
+
+.asset-name {
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.asset-meta {
+  font-size: 12px;
+  color: #64748b;
+}
+
+.positive {
+  color: #15803d;
+  font-weight: 700;
+}
+
+.negative {
+  color: #b91c1c;
+  font-weight: 700;
+}
+
+.empty-state,
+.error-box {
+  padding: 32px;
+  border-radius: 16px;
+  text-align: center;
+}
+
+.empty-state {
+  background: #fff;
+  color: #64748b;
+  border: 1px solid #e2e8f0;
+}
+
+.error-box {
+  background: #fef2f2;
+  color: #b91c1c;
+}
+
+@media (max-width: 960px) {
+  .page-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .summary-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .summary-grid {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/src/views/EmployeeSecuritiesView.vue
+++ b/src/views/EmployeeSecuritiesView.vue
@@ -1,0 +1,295 @@
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+import { RouterLink } from 'vue-router'
+import { useEmployeeMarketStore } from '../stores/employeeMarket'
+
+const marketStore = useEmployeeMarketStore()
+const query = ref('')
+
+const filteredListings = computed(() => {
+  const needle = query.value.trim().toLowerCase()
+  if (!needle) return marketStore.listings
+
+  return marketStore.listings.filter((listing) =>
+    listing.ticker.toLowerCase().includes(needle) ||
+    listing.name.toLowerCase().includes(needle)
+  )
+})
+
+onMounted(async () => {
+  await Promise.all([
+    marketStore.fetchExchanges(),
+    marketStore.fetchListings(),
+  ])
+})
+</script>
+
+<template>
+  <div class="market-page">
+    <div class="page-header">
+      <div>
+        <h1>Hartije od vrednosti</h1>
+        <p>Read-only pregled berzi i akcija za zaposlene sa traderskim ovlascenjima.</p>
+      </div>
+      <RouterLink to="/portfolio" class="portfolio-link">Otvori portfolio</RouterLink>
+    </div>
+
+    <section class="panel">
+      <div class="panel-head">
+        <h2>Berze</h2>
+        <span class="panel-meta">{{ marketStore.exchanges.length }} aktivnih izvora</span>
+      </div>
+      <div class="exchange-grid">
+        <article v-for="exchange in marketStore.exchanges" :key="exchange.acronym" class="exchange-card">
+          <div class="exchange-top">
+            <div>
+              <div class="exchange-acronym">{{ exchange.acronym }}</div>
+              <div class="exchange-name">{{ exchange.name }}</div>
+            </div>
+            <span class="exchange-status" :class="{ enabled: exchange.enabled }">
+              {{ exchange.enabled ? 'Enabled' : 'Disabled' }}
+            </span>
+          </div>
+          <div class="exchange-meta">{{ exchange.polity }} | {{ exchange.currency }} | {{ exchange.micCode }}</div>
+          <div class="exchange-hours">{{ exchange.timezone }} | {{ exchange.workingHours }}</div>
+        </article>
+      </div>
+    </section>
+
+    <section class="panel">
+      <div class="panel-head">
+        <h2>Akcije</h2>
+        <div class="search-box">
+          <input v-model="query" type="text" placeholder="Pretraga po ticker-u ili nazivu" />
+        </div>
+      </div>
+
+      <div v-if="marketStore.loading" class="empty-state">Ucitavam listings...</div>
+      <div v-else-if="marketStore.error" class="error-box">{{ marketStore.error }}</div>
+      <div v-else-if="filteredListings.length === 0" class="empty-state">Nema rezultata za zadatu pretragu.</div>
+      <div v-else class="table-wrap">
+        <table class="market-table">
+          <thead>
+            <tr>
+              <th>Ticker</th>
+              <th>Naziv</th>
+              <th>Berza</th>
+              <th>Cena</th>
+              <th>Ask</th>
+              <th>Bid</th>
+              <th>Volume</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="listing in filteredListings" :key="listing.ticker">
+              <td class="ticker">{{ listing.ticker }}</td>
+              <td>{{ listing.name }}</td>
+              <td>{{ listing.exchange.acronym }}</td>
+              <td>{{ listing.price.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 }) }} {{ listing.exchange.currency }}</td>
+              <td>{{ listing.ask.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 }) }}</td>
+              <td>{{ listing.bid.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 }) }}</td>
+              <td>{{ listing.volume.toLocaleString('en-US') }}</td>
+              <td>
+                <RouterLink :to="`/securities/${listing.ticker}`" class="details-link">Detalji</RouterLink>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+  </div>
+</template>
+
+<style scoped>
+.market-page {
+  padding: 32px;
+  max-width: 1280px;
+  margin: 0 auto;
+}
+
+.page-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 20px;
+  margin-bottom: 24px;
+}
+
+.page-header h1 {
+  margin: 0;
+  font-size: 30px;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.page-header p {
+  margin: 8px 0 0;
+  color: #64748b;
+}
+
+.portfolio-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 16px;
+  border-radius: 10px;
+  background: #0f172a;
+  color: #fff;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.panel {
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 16px;
+  padding: 24px;
+  margin-bottom: 24px;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.04);
+}
+
+.panel-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 18px;
+}
+
+.panel-head h2 {
+  margin: 0;
+  font-size: 18px;
+  color: #0f172a;
+}
+
+.panel-meta {
+  color: #64748b;
+  font-size: 13px;
+}
+
+.search-box input {
+  width: 320px;
+  max-width: 100%;
+  padding: 10px 14px;
+  border: 1px solid #cbd5e1;
+  border-radius: 10px;
+  font-size: 14px;
+}
+
+.exchange-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 14px;
+}
+
+.exchange-card {
+  border: 1px solid #e2e8f0;
+  border-radius: 14px;
+  padding: 16px;
+  background: linear-gradient(180deg, #ffffff 0%, #f8fafc 100%);
+}
+
+.exchange-top {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.exchange-acronym {
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  color: #2563eb;
+}
+
+.exchange-name {
+  margin-top: 6px;
+  font-size: 16px;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.exchange-status {
+  height: fit-content;
+  padding: 4px 8px;
+  border-radius: 999px;
+  background: #e2e8f0;
+  color: #475569;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.exchange-status.enabled {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.exchange-meta,
+.exchange-hours {
+  margin-top: 10px;
+  color: #64748b;
+  font-size: 13px;
+}
+
+.table-wrap {
+  overflow-x: auto;
+}
+
+.market-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.market-table th,
+.market-table td {
+  padding: 14px 12px;
+  border-bottom: 1px solid #e2e8f0;
+  text-align: left;
+  font-size: 14px;
+}
+
+.market-table th {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #64748b;
+}
+
+.ticker {
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.details-link {
+  color: #2563eb;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.empty-state,
+.error-box {
+  padding: 32px;
+  text-align: center;
+  border-radius: 12px;
+}
+
+.empty-state {
+  background: #f8fafc;
+  color: #64748b;
+}
+
+.error-box {
+  background: #fef2f2;
+  color: #b91c1c;
+}
+
+@media (max-width: 900px) {
+  .page-header,
+  .panel-head {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}
+</style>

--- a/src/views/EmployeeSecurityDetailsView.vue
+++ b/src/views/EmployeeSecurityDetailsView.vue
@@ -1,0 +1,306 @@
+<script setup lang="ts">
+import { computed, onMounted, watch } from 'vue'
+import { RouterLink, useRoute } from 'vue-router'
+import { useEmployeeMarketStore } from '../stores/employeeMarket'
+
+const route = useRoute()
+const marketStore = useEmployeeMarketStore()
+
+const ticker = computed(() => String(route.params.ticker || ''))
+
+async function loadDetails() {
+  if (!ticker.value) return
+  await marketStore.fetchListingDetails(ticker.value)
+}
+
+onMounted(loadDetails)
+watch(ticker, loadDetails)
+</script>
+
+<template>
+  <div class="details-page">
+    <RouterLink to="/securities" class="back-link">Nazad na hartije</RouterLink>
+
+    <div v-if="marketStore.detailsLoading" class="empty-state">Ucitavam detalje hartije...</div>
+    <div v-else-if="marketStore.error" class="error-box">{{ marketStore.error }}</div>
+    <div v-else-if="!marketStore.currentListing" class="empty-state">Trazena hartija nije pronadjena.</div>
+    <template v-else>
+      <div class="hero">
+        <div>
+          <div class="ticker-pill">{{ marketStore.currentListing.ticker }}</div>
+          <h1>{{ marketStore.currentListing.name }}</h1>
+          <p>{{ marketStore.currentListing.exchange.name }} | {{ marketStore.currentListing.exchange.currency }}</p>
+        </div>
+        <div class="hero-price">
+          {{ marketStore.currentListing.price.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 }) }}
+          <span>{{ marketStore.currentListing.exchange.currency }}</span>
+        </div>
+      </div>
+
+      <div class="stats-grid">
+        <div class="stat-card">
+          <span>Ask</span>
+          <strong>{{ marketStore.currentListing.ask.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 }) }}</strong>
+        </div>
+        <div class="stat-card">
+          <span>Bid</span>
+          <strong>{{ marketStore.currentListing.bid.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 }) }}</strong>
+        </div>
+        <div class="stat-card">
+          <span>Volume</span>
+          <strong>{{ marketStore.currentListing.volume.toLocaleString('en-US') }}</strong>
+        </div>
+        <div class="stat-card">
+          <span>Last refresh</span>
+          <strong>{{ new Date(marketStore.currentListing.lastRefresh).toLocaleString('sr-RS') }}</strong>
+        </div>
+      </div>
+
+      <section class="panel info-panel">
+        <div>
+          <h2>Osnovni podaci</h2>
+          <ul class="meta-list">
+            <li><span>Berza</span><strong>{{ marketStore.currentListing.exchange.acronym }}</strong></li>
+            <li><span>MIC</span><strong>{{ marketStore.currentListing.exchange.micCode }}</strong></li>
+            <li><span>Tip</span><strong>{{ marketStore.currentListing.type }}</strong></li>
+            <li><span>Valuta</span><strong>{{ marketStore.currentListing.exchange.currency }}</strong></li>
+          </ul>
+        </div>
+      </section>
+
+      <section class="panel">
+        <div class="panel-head">
+          <h2>Istorija kretanja cene</h2>
+          <span>{{ marketStore.currentHistory.length }} dana</span>
+        </div>
+
+        <div class="table-wrap">
+          <table class="history-table">
+            <thead>
+              <tr>
+                <th>Datum</th>
+                <th>Cena</th>
+                <th>High</th>
+                <th>Low</th>
+                <th>Promena</th>
+                <th>Volume</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="point in marketStore.currentHistory" :key="point.date">
+                <td>{{ point.date }}</td>
+                <td>{{ point.price.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 }) }}</td>
+                <td>{{ point.high.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 }) }}</td>
+                <td>{{ point.low.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 }) }}</td>
+                <td :class="{ positive: point.change >= 0, negative: point.change < 0 }">
+                  {{ point.change.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 }) }}
+                </td>
+                <td>{{ point.volume.toLocaleString('en-US') }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </template>
+  </div>
+</template>
+
+<style scoped>
+.details-page {
+  padding: 32px;
+  max-width: 1180px;
+  margin: 0 auto;
+}
+
+.back-link {
+  display: inline-block;
+  margin-bottom: 18px;
+  color: #2563eb;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.hero {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 20px;
+  margin-bottom: 22px;
+}
+
+.ticker-pill {
+  display: inline-block;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: #dbeafe;
+  color: #1d4ed8;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.hero h1 {
+  margin: 10px 0 6px;
+  font-size: 32px;
+  color: #0f172a;
+}
+
+.hero p {
+  margin: 0;
+  color: #64748b;
+}
+
+.hero-price {
+  font-size: 42px;
+  font-weight: 800;
+  color: #0f172a;
+}
+
+.hero-price span {
+  display: block;
+  font-size: 14px;
+  font-weight: 600;
+  color: #64748b;
+}
+
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 14px;
+  margin-bottom: 24px;
+}
+
+.stat-card,
+.panel {
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 16px;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.04);
+}
+
+.stat-card {
+  padding: 18px;
+}
+
+.stat-card span {
+  display: block;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #64748b;
+}
+
+.stat-card strong {
+  display: block;
+  margin-top: 8px;
+  font-size: 20px;
+  color: #0f172a;
+}
+
+.panel {
+  padding: 24px;
+  margin-bottom: 24px;
+}
+
+.panel-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 18px;
+}
+
+.panel-head h2 {
+  margin: 0;
+  color: #0f172a;
+}
+
+.meta-list {
+  list-style: none;
+  padding: 0;
+  margin: 18px 0 0;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 14px;
+}
+
+.meta-list li {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 14px;
+  border-radius: 12px;
+  background: #f8fafc;
+}
+
+.meta-list span {
+  color: #64748b;
+}
+
+.meta-list strong {
+  color: #0f172a;
+}
+
+.table-wrap {
+  overflow-x: auto;
+}
+
+.history-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.history-table th,
+.history-table td {
+  padding: 12px 10px;
+  border-bottom: 1px solid #e2e8f0;
+  text-align: left;
+}
+
+.history-table th {
+  font-size: 12px;
+  text-transform: uppercase;
+  color: #64748b;
+}
+
+.positive {
+  color: #15803d;
+  font-weight: 700;
+}
+
+.negative {
+  color: #b91c1c;
+  font-weight: 700;
+}
+
+.empty-state,
+.error-box {
+  padding: 32px;
+  border-radius: 16px;
+  text-align: center;
+}
+
+.empty-state {
+  background: #fff;
+  color: #64748b;
+  border: 1px solid #e2e8f0;
+}
+
+.error-box {
+  background: #fef2f2;
+  color: #b91c1c;
+}
+
+@media (max-width: 900px) {
+  .hero {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .stats-grid,
+  .meta-list {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/src/views/client/ClientLayout.vue
+++ b/src/views/client/ClientLayout.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 import { useRouter, RouterLink, useRoute } from 'vue-router'
 import { useClientAuthStore } from '../../stores/clientAuth'
 
@@ -7,6 +7,7 @@ const router = useRouter()
 const route = useRoute()
 const clientAuth = useClientAuthStore()
 const paymentsOpen = ref(true)
+const canAccessMarket = computed(() => clientAuth.hasPermission('clientTrading'))
 
 function logout() {
   clientAuth.logout()
@@ -39,6 +40,14 @@ function isPaymentSection() {
 
         <RouterLink to="/client/accounts" class="sidebar-link" :class="{ active: isActive('/client/accounts') }">
           <span class="sidebar-icon">o</span><span>Racuni</span>
+        </RouterLink>
+
+        <RouterLink v-if="canAccessMarket" to="/client/securities" class="sidebar-link" :class="{ active: isActive('/client/securities') }">
+          <span class="sidebar-icon">%</span><span>Hartije</span>
+        </RouterLink>
+
+        <RouterLink v-if="canAccessMarket" to="/client/portfolio" class="sidebar-link" :class="{ active: isActive('/client/portfolio') }">
+          <span class="sidebar-icon">$</span><span>Portfolio</span>
         </RouterLink>
 
         <RouterLink to="/client/transfers" class="sidebar-link" :class="{ active: isActive('/client/transfers') }">

--- a/src/views/client/ClientPortfolioView.vue
+++ b/src/views/client/ClientPortfolioView.vue
@@ -1,0 +1,332 @@
+<script setup lang="ts">
+import { computed, onMounted } from 'vue'
+import { RouterLink } from 'vue-router'
+import { useMarketStore } from '../../stores/market'
+
+const marketStore = useMarketStore()
+
+const holdingsCount = computed(() => marketStore.portfolio?.items.length ?? 0)
+
+const sortedItems = computed(() => {
+  if (!marketStore.portfolio) return []
+  return [...marketStore.portfolio.items].sort((left, right) => {
+    return right.marketValue - left.marketValue || left.ticker.localeCompare(right.ticker)
+  })
+})
+
+const concentrationRatio = computed(() => {
+  const total = marketStore.portfolio?.estimatedValue ?? 0
+  const topItem = sortedItems.value[0]
+  if (!total || !topItem) return 0
+  return (topItem.marketValue / total) * 100
+})
+
+const formatter = new Intl.NumberFormat('en-US', {
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+})
+
+function formatAmount(value: number) {
+  return formatter.format(value)
+}
+
+function positionShare(marketValue: number) {
+  const total = marketStore.portfolio?.estimatedValue ?? 0
+  if (!total) return 0
+  return (marketValue / total) * 100
+}
+
+onMounted(async () => {
+  await marketStore.fetchPortfolio()
+})
+</script>
+
+<template>
+  <div class="portfolio-page">
+    <div class="page-header">
+      <div>
+        <h1>Portfolio</h1>
+        <p>Read-only pregled pozicija zasnovan na trenutnim market podacima iz Sprint 4 foundation sloja.</p>
+      </div>
+      <RouterLink to="/client/securities" class="secondary-link">Nazad na hartije</RouterLink>
+    </div>
+
+    <div v-if="marketStore.portfolioLoading" class="empty-state">Ucitavam portfolio...</div>
+    <div v-else-if="marketStore.error" class="error-box">{{ marketStore.error }}</div>
+    <div v-else-if="!marketStore.portfolio" class="empty-state">Portfolio trenutno nije dostupan.</div>
+    <template v-else>
+      <div class="summary-grid">
+        <article class="summary-card primary">
+          <span>Ukupna procenjena vrednost</span>
+          <strong>{{ formatAmount(marketStore.portfolio.estimatedValue) }}</strong>
+        </article>
+        <article class="summary-card">
+          <span>Nerealizovani P/L</span>
+          <strong :class="{ positive: marketStore.portfolio.unrealizedPnL >= 0, negative: marketStore.portfolio.unrealizedPnL < 0 }">
+            {{ formatAmount(marketStore.portfolio.unrealizedPnL) }}
+          </strong>
+        </article>
+        <article class="summary-card">
+          <span>Broj pozicija</span>
+          <strong>{{ holdingsCount }}</strong>
+        </article>
+        <article class="summary-card">
+          <span>Najveca pozicija</span>
+          <strong>{{ concentrationRatio.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 }) }}%</strong>
+        </article>
+      </div>
+
+      <section class="panel">
+        <div class="panel-head">
+          <div>
+            <h2>Pozicije</h2>
+            <span class="panel-meta">Sortirano po procenjenoj vrednosti, najvece prvo.</span>
+          </div>
+          <span class="panel-meta">Generisano {{ new Date(marketStore.portfolio.generatedAt).toLocaleString('sr-RS') }}</span>
+        </div>
+
+        <div v-if="sortedItems.length === 0" class="empty-inline">Portfolio trenutno nema prikazane pozicije.</div>
+        <div v-else class="table-wrap">
+          <table class="portfolio-table">
+            <thead>
+              <tr>
+                <th>Ticker</th>
+                <th>Naziv</th>
+                <th>Kolicina</th>
+                <th>Avg price</th>
+                <th>Current price</th>
+                <th>Market value</th>
+                <th>Udeo</th>
+                <th>P/L</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="item in sortedItems" :key="item.ticker">
+                <td class="ticker">
+                  <RouterLink :to="`/client/securities/${item.ticker}`">{{ item.ticker }}</RouterLink>
+                </td>
+                <td>
+                  <div class="asset-name">{{ item.name }}</div>
+                  <div class="asset-meta">{{ item.exchange }} | {{ item.currency }}</div>
+                </td>
+                <td>{{ item.quantity.toLocaleString('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 2 }) }}</td>
+                <td>{{ formatAmount(item.averagePrice) }}</td>
+                <td>{{ formatAmount(item.currentPrice) }}</td>
+                <td>{{ formatAmount(item.marketValue) }}</td>
+                <td>{{ positionShare(item.marketValue).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 }) }}%</td>
+                <td>
+                  <div :class="{ positive: item.pnl >= 0, negative: item.pnl < 0 }">
+                    {{ formatAmount(item.pnl) }}
+                  </div>
+                  <div class="asset-meta">{{ item.pnlPercent.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 }) }}%</div>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </template>
+  </div>
+</template>
+
+<style scoped>
+.portfolio-page {
+  padding: 32px;
+  max-width: 1220px;
+  margin: 0 auto;
+}
+
+.page-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 20px;
+  margin-bottom: 24px;
+}
+
+.page-header h1 {
+  margin: 0;
+  font-size: 30px;
+  color: #0f172a;
+}
+
+.page-header p {
+  margin: 8px 0 0;
+  color: #64748b;
+}
+
+.secondary-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 16px;
+  border-radius: 10px;
+  background: #fff;
+  border: 1px solid #cbd5e1;
+  color: #0f172a;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.summary-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+  margin-bottom: 24px;
+}
+
+.summary-card {
+  background: #fff;
+  border-radius: 16px;
+  padding: 20px;
+  border: 1px solid #e2e8f0;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.04);
+}
+
+.summary-card.primary {
+  background: linear-gradient(135deg, #0f172a 0%, #2563eb 100%);
+  color: #fff;
+  border: none;
+}
+
+.summary-card span {
+  display: block;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #64748b;
+}
+
+.summary-card.primary span {
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.summary-card strong {
+  display: block;
+  margin-top: 10px;
+  font-size: 24px;
+  color: #0f172a;
+}
+
+.summary-card.primary strong {
+  color: #fff;
+}
+
+.panel {
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 16px;
+  padding: 24px;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.04);
+}
+
+.panel-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 18px;
+}
+
+.panel-head h2 {
+  margin: 0;
+  color: #0f172a;
+}
+
+.panel-meta {
+  font-size: 13px;
+  color: #64748b;
+}
+
+.table-wrap {
+  overflow-x: auto;
+}
+
+.portfolio-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.portfolio-table th,
+.portfolio-table td {
+  padding: 14px 12px;
+  border-bottom: 1px solid #e2e8f0;
+  text-align: left;
+}
+
+.portfolio-table th {
+  font-size: 12px;
+  text-transform: uppercase;
+  color: #64748b;
+}
+
+.ticker a {
+  color: #2563eb;
+  text-decoration: none;
+  font-weight: 700;
+}
+
+.asset-name {
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.asset-meta {
+  font-size: 12px;
+  color: #64748b;
+}
+
+.positive {
+  color: #15803d;
+  font-weight: 700;
+}
+
+.negative {
+  color: #b91c1c;
+  font-weight: 700;
+}
+
+.empty-state,
+.error-box {
+  padding: 32px;
+  border-radius: 16px;
+  text-align: center;
+}
+
+.empty-state {
+  background: #fff;
+  color: #64748b;
+  border: 1px solid #e2e8f0;
+}
+
+.error-box {
+  background: #fef2f2;
+  color: #b91c1c;
+}
+
+.empty-inline {
+  padding: 22px;
+  border-radius: 12px;
+  background: #f8fafc;
+  color: #64748b;
+  text-align: center;
+}
+
+@media (max-width: 960px) {
+  .page-header,
+  .panel-head {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .summary-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .summary-grid {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/src/views/client/ClientSecuritiesView.vue
+++ b/src/views/client/ClientSecuritiesView.vue
@@ -1,0 +1,446 @@
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+import { RouterLink } from 'vue-router'
+import { useMarketStore } from '../../stores/market'
+
+type SortOption = 'tickerAsc' | 'nameAsc' | 'priceDesc' | 'priceAsc' | 'volumeDesc'
+
+const marketStore = useMarketStore()
+const query = ref('')
+const typeFilter = ref('all')
+const sortBy = ref<SortOption>('tickerAsc')
+
+const formatter = new Intl.NumberFormat('en-US', {
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+})
+
+const volumeFormatter = new Intl.NumberFormat('en-US')
+
+const typeOptions = computed(() => {
+  const options = new Set<string>()
+  marketStore.listings.forEach((listing) => options.add(listing.type))
+  return ['all', ...Array.from(options).sort()]
+})
+
+const filteredListings = computed(() => {
+  const needle = query.value.trim().toLowerCase()
+  const filtered = marketStore.listings.filter((listing) => {
+    const matchesQuery =
+      !needle ||
+      listing.ticker.toLowerCase().includes(needle) ||
+      listing.name.toLowerCase().includes(needle)
+    const matchesType = typeFilter.value === 'all' || listing.type === typeFilter.value
+    return matchesQuery && matchesType
+  })
+
+  return [...filtered].sort((left, right) => {
+    switch (sortBy.value) {
+      case 'nameAsc':
+        return left.name.localeCompare(right.name) || left.ticker.localeCompare(right.ticker)
+      case 'priceDesc':
+        return right.price - left.price || left.ticker.localeCompare(right.ticker)
+      case 'priceAsc':
+        return left.price - right.price || left.ticker.localeCompare(right.ticker)
+      case 'volumeDesc':
+        return right.volume - left.volume || left.ticker.localeCompare(right.ticker)
+      case 'tickerAsc':
+      default:
+        return left.ticker.localeCompare(right.ticker)
+    }
+  })
+})
+
+const enabledExchanges = computed(() =>
+  marketStore.exchanges.filter((exchange) => exchange.enabled).length
+)
+
+function formatPrice(value: number) {
+  return formatter.format(value)
+}
+
+onMounted(async () => {
+  await Promise.all([
+    marketStore.fetchExchanges(),
+    marketStore.fetchListings(),
+  ])
+})
+</script>
+
+<template>
+  <div class="market-page">
+    <div class="page-header">
+      <div>
+        <h1>Hartije od vrednosti</h1>
+        <p>Read-only pregled akcija i berzi dostupan klijentima sa trading dozvolom.</p>
+      </div>
+      <RouterLink to="/client/portfolio" class="portfolio-link">Otvori portfolio</RouterLink>
+    </div>
+
+    <div class="summary-grid">
+      <article class="summary-card">
+        <span>Hartije</span>
+        <strong>{{ marketStore.listings.length }}</strong>
+      </article>
+      <article class="summary-card">
+        <span>Aktivne berze</span>
+        <strong>{{ enabledExchanges }}</strong>
+      </article>
+      <article class="summary-card">
+        <span>Tipovi</span>
+        <strong>{{ typeOptions.length - 1 }}</strong>
+      </article>
+    </div>
+
+    <section class="panel">
+      <div class="panel-head">
+        <h2>Berze</h2>
+        <span class="panel-meta">{{ marketStore.exchanges.length }} izvora podataka</span>
+      </div>
+      <div class="exchange-grid">
+        <article v-for="exchange in marketStore.exchanges" :key="exchange.acronym" class="exchange-card">
+          <div class="exchange-top">
+            <div>
+              <div class="exchange-acronym">{{ exchange.acronym }}</div>
+              <div class="exchange-name">{{ exchange.name }}</div>
+            </div>
+            <span class="exchange-status" :class="{ enabled: exchange.enabled }">
+              {{ exchange.enabled ? 'Enabled' : 'Disabled' }}
+            </span>
+          </div>
+          <div class="exchange-meta">{{ exchange.polity }} | {{ exchange.currency }} | {{ exchange.micCode }}</div>
+          <div class="exchange-hours">{{ exchange.timezone }} | {{ exchange.workingHours }}</div>
+        </article>
+      </div>
+    </section>
+
+    <section class="panel">
+      <div class="panel-head panel-head-stack">
+        <div>
+          <h2>Akcije</h2>
+          <span class="panel-meta">Pretraga po ticker-u i nazivu uz stabilno sortiranje.</span>
+        </div>
+        <div class="controls-grid">
+          <input v-model="query" type="text" placeholder="Pretraga po ticker-u ili nazivu" />
+          <select v-model="typeFilter">
+            <option v-for="option in typeOptions" :key="option" :value="option">
+              {{ option === 'all' ? 'Svi tipovi' : option }}
+            </option>
+          </select>
+          <select v-model="sortBy">
+            <option value="tickerAsc">Ticker A-Z</option>
+            <option value="nameAsc">Naziv A-Z</option>
+            <option value="priceDesc">Cena opadajuce</option>
+            <option value="priceAsc">Cena rastuce</option>
+            <option value="volumeDesc">Volume opadajuce</option>
+          </select>
+        </div>
+      </div>
+
+      <div v-if="marketStore.loading" class="empty-state">Ucitavam listings...</div>
+      <div v-else-if="marketStore.error" class="error-box">{{ marketStore.error }}</div>
+      <div v-else-if="marketStore.listings.length === 0" class="empty-state">Market podaci trenutno nisu dostupni.</div>
+      <div v-else-if="filteredListings.length === 0" class="empty-state">Nema rezultata za zadate filtere.</div>
+      <div v-else class="table-wrap">
+        <table class="market-table">
+          <thead>
+            <tr>
+              <th>Ticker</th>
+              <th>Naziv</th>
+              <th>Berza</th>
+              <th>Cena</th>
+              <th>Ask</th>
+              <th>Bid</th>
+              <th>Tip</th>
+              <th>Volume</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="listing in filteredListings" :key="listing.ticker">
+              <td class="ticker">{{ listing.ticker }}</td>
+              <td>
+                <div class="name-cell">{{ listing.name }}</div>
+                <div class="cell-meta">Osvezeno {{ new Date(listing.lastRefresh).toLocaleString('sr-RS') }}</div>
+              </td>
+              <td>{{ listing.exchange.acronym }}</td>
+              <td>{{ formatPrice(listing.price) }} {{ listing.exchange.currency }}</td>
+              <td>{{ formatPrice(listing.ask) }}</td>
+              <td>{{ formatPrice(listing.bid) }}</td>
+              <td><span class="type-pill">{{ listing.type }}</span></td>
+              <td>{{ volumeFormatter.format(listing.volume) }}</td>
+              <td>
+                <RouterLink :to="`/client/securities/${listing.ticker}`" class="details-link">Detalji</RouterLink>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+  </div>
+</template>
+
+<style scoped>
+.market-page {
+  padding: 32px;
+  max-width: 1280px;
+  margin: 0 auto;
+}
+
+.page-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 20px;
+  margin-bottom: 24px;
+}
+
+.page-header h1 {
+  margin: 0;
+  font-size: 30px;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.page-header p {
+  margin: 8px 0 0;
+  color: #64748b;
+}
+
+.portfolio-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 16px;
+  border-radius: 10px;
+  background: #0f172a;
+  color: #fff;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.summary-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+  margin-bottom: 24px;
+}
+
+.summary-card,
+.panel {
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 16px;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.04);
+}
+
+.summary-card {
+  padding: 18px 20px;
+}
+
+.summary-card span {
+  display: block;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #64748b;
+}
+
+.summary-card strong {
+  display: block;
+  margin-top: 10px;
+  font-size: 26px;
+  color: #0f172a;
+}
+
+.panel {
+  padding: 24px;
+  margin-bottom: 24px;
+}
+
+.panel-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 18px;
+}
+
+.panel-head-stack {
+  align-items: flex-start;
+}
+
+.panel-head h2 {
+  margin: 0;
+  font-size: 18px;
+  color: #0f172a;
+}
+
+.panel-meta {
+  color: #64748b;
+  font-size: 13px;
+}
+
+.controls-grid {
+  display: grid;
+  grid-template-columns: minmax(240px, 1.4fr) 180px 180px;
+  gap: 12px;
+  width: min(100%, 760px);
+}
+
+.controls-grid input,
+.controls-grid select {
+  width: 100%;
+  padding: 10px 14px;
+  border: 1px solid #cbd5e1;
+  border-radius: 10px;
+  font-size: 14px;
+  background: #fff;
+}
+
+.exchange-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 14px;
+}
+
+.exchange-card {
+  border: 1px solid #e2e8f0;
+  border-radius: 14px;
+  padding: 16px;
+  background: linear-gradient(180deg, #ffffff 0%, #f8fafc 100%);
+}
+
+.exchange-top {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.exchange-acronym {
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  color: #2563eb;
+}
+
+.exchange-name {
+  margin-top: 6px;
+  font-size: 16px;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.exchange-status {
+  height: fit-content;
+  padding: 4px 8px;
+  border-radius: 999px;
+  background: #e2e8f0;
+  color: #475569;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.exchange-status.enabled {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.exchange-meta,
+.exchange-hours {
+  margin-top: 10px;
+  color: #64748b;
+  font-size: 13px;
+}
+
+.table-wrap {
+  overflow-x: auto;
+}
+
+.market-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.market-table th,
+.market-table td {
+  padding: 14px 12px;
+  border-bottom: 1px solid #e2e8f0;
+  text-align: left;
+  font-size: 14px;
+  vertical-align: top;
+}
+
+.market-table th {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #64748b;
+}
+
+.ticker {
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.name-cell {
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.cell-meta {
+  margin-top: 4px;
+  font-size: 12px;
+  color: #64748b;
+}
+
+.type-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: #e0f2fe;
+  color: #0369a1;
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.details-link {
+  color: #2563eb;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.empty-state,
+.error-box {
+  padding: 32px;
+  text-align: center;
+  border-radius: 12px;
+}
+
+.empty-state {
+  background: #f8fafc;
+  color: #64748b;
+}
+
+.error-box {
+  background: #fef2f2;
+  color: #b91c1c;
+}
+
+@media (max-width: 900px) {
+  .page-header,
+  .panel-head {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .summary-grid,
+  .controls-grid {
+    grid-template-columns: 1fr;
+    width: 100%;
+  }
+}
+</style>

--- a/src/views/client/ClientSecurityDetailsView.vue
+++ b/src/views/client/ClientSecurityDetailsView.vue
@@ -1,0 +1,419 @@
+<script setup lang="ts">
+import { computed, onMounted, watch } from 'vue'
+import { RouterLink, useRoute } from 'vue-router'
+import { useMarketStore } from '../../stores/market'
+
+const route = useRoute()
+const marketStore = useMarketStore()
+
+const priceFormatter = new Intl.NumberFormat('en-US', {
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+})
+
+const volumeFormatter = new Intl.NumberFormat('en-US')
+
+const ticker = computed(() => String(route.params.ticker || '').trim().toUpperCase())
+
+const historyRows = computed(() =>
+  [...marketStore.currentHistory].sort((left, right) => right.date.localeCompare(left.date))
+)
+
+const latestHistoryPoint = computed(() => historyRows.value[0] ?? null)
+
+const historyHigh = computed(() => {
+  if (historyRows.value.length === 0) return null
+  return Math.max(...historyRows.value.map((point) => point.high))
+})
+
+const historyLow = computed(() => {
+  if (historyRows.value.length === 0) return null
+  return Math.min(...historyRows.value.map((point) => point.low))
+})
+
+const historyAverage = computed(() => {
+  if (historyRows.value.length === 0) return null
+  const total = historyRows.value.reduce((sum, point) => sum + point.price, 0)
+  return total / historyRows.value.length
+})
+
+function formatPrice(value: number | null | undefined) {
+  if (value == null) return 'N/A'
+  return priceFormatter.format(value)
+}
+
+async function loadDetails() {
+  if (!ticker.value) return
+  await marketStore.fetchListingDetails(ticker.value)
+}
+
+onMounted(loadDetails)
+watch(ticker, loadDetails)
+</script>
+
+<template>
+  <div class="details-page">
+    <RouterLink to="/client/securities" class="back-link">Nazad na hartije</RouterLink>
+
+    <div v-if="!ticker" class="empty-state">
+      <h2>Nedostaje ticker</h2>
+      <p>Izaberite hartiju sa liste kako biste videli detalje.</p>
+      <RouterLink to="/client/securities" class="action-link">Nazad na listu</RouterLink>
+    </div>
+    <div v-else-if="marketStore.detailsLoading" class="empty-state">Ucitavam detalje hartije...</div>
+    <div v-else-if="marketStore.error" class="error-box">
+      <h2>Detalji nisu dostupni</h2>
+      <p>{{ marketStore.error }}</p>
+      <RouterLink to="/client/securities" class="action-link action-link-light">Povratak na listu</RouterLink>
+    </div>
+    <div v-else-if="!marketStore.currentListing" class="empty-state">
+      <h2>Hartija nije pronadjena</h2>
+      <p>Ticker {{ ticker }} trenutno nema dostupne podatke.</p>
+      <RouterLink to="/client/securities" class="action-link">Nazad na listu</RouterLink>
+    </div>
+    <template v-else>
+      <div class="hero">
+        <div>
+          <div class="ticker-pill">{{ marketStore.currentListing.ticker }}</div>
+          <h1>{{ marketStore.currentListing.name }}</h1>
+          <p>{{ marketStore.currentListing.exchange.name }} | {{ marketStore.currentListing.exchange.currency }}</p>
+        </div>
+        <div class="hero-price">
+          {{ formatPrice(marketStore.currentListing.price) }}
+          <span>{{ marketStore.currentListing.exchange.currency }}</span>
+        </div>
+      </div>
+
+      <div class="stats-grid">
+        <div class="stat-card">
+          <span>Ask</span>
+          <strong>{{ formatPrice(marketStore.currentListing.ask) }}</strong>
+        </div>
+        <div class="stat-card">
+          <span>Bid</span>
+          <strong>{{ formatPrice(marketStore.currentListing.bid) }}</strong>
+        </div>
+        <div class="stat-card">
+          <span>Volume</span>
+          <strong>{{ volumeFormatter.format(marketStore.currentListing.volume) }}</strong>
+        </div>
+        <div class="stat-card">
+          <span>Last refresh</span>
+          <strong>{{ new Date(marketStore.currentListing.lastRefresh).toLocaleString('sr-RS') }}</strong>
+        </div>
+      </div>
+
+      <div class="summary-grid">
+        <article class="summary-card">
+          <span>30d high</span>
+          <strong>{{ formatPrice(historyHigh) }}</strong>
+        </article>
+        <article class="summary-card">
+          <span>30d low</span>
+          <strong>{{ formatPrice(historyLow) }}</strong>
+        </article>
+        <article class="summary-card">
+          <span>30d avg</span>
+          <strong>{{ formatPrice(historyAverage) }}</strong>
+        </article>
+        <article class="summary-card">
+          <span>Poslednja promena</span>
+          <strong :class="{ positive: (latestHistoryPoint?.change ?? 0) >= 0, negative: (latestHistoryPoint?.change ?? 0) < 0 }">
+            {{ latestHistoryPoint ? formatPrice(latestHistoryPoint.change) : 'N/A' }}
+          </strong>
+        </article>
+      </div>
+
+      <section class="panel info-panel">
+        <div class="panel-head">
+          <h2>Osnovni podaci</h2>
+        </div>
+        <ul class="meta-list">
+          <li><span>Naziv</span><strong>{{ marketStore.currentListing.name }}</strong></li>
+          <li><span>Berza</span><strong>{{ marketStore.currentListing.exchange.acronym }}</strong></li>
+          <li><span>MIC</span><strong>{{ marketStore.currentListing.exchange.micCode }}</strong></li>
+          <li><span>Tip</span><strong>{{ marketStore.currentListing.type }}</strong></li>
+          <li><span>Valuta</span><strong>{{ marketStore.currentListing.exchange.currency }}</strong></li>
+          <li><span>Trziste</span><strong>{{ marketStore.currentListing.exchange.name }}</strong></li>
+        </ul>
+      </section>
+
+      <section class="panel">
+        <div class="panel-head">
+          <h2>Istorija kretanja cene</h2>
+          <span>{{ historyRows.length }} dana, najnovije prvo</span>
+        </div>
+
+        <div v-if="historyRows.length === 0" class="empty-inline">Istorija trenutno nije dostupna.</div>
+        <div v-else class="table-wrap">
+          <table class="history-table">
+            <thead>
+              <tr>
+                <th>Datum</th>
+                <th>Cena</th>
+                <th>High</th>
+                <th>Low</th>
+                <th>Promena</th>
+                <th>Volume</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="point in historyRows" :key="point.date">
+                <td>{{ point.date }}</td>
+                <td>{{ formatPrice(point.price) }}</td>
+                <td>{{ formatPrice(point.high) }}</td>
+                <td>{{ formatPrice(point.low) }}</td>
+                <td :class="{ positive: point.change >= 0, negative: point.change < 0 }">
+                  {{ formatPrice(point.change) }}
+                </td>
+                <td>{{ volumeFormatter.format(point.volume) }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </template>
+  </div>
+</template>
+
+<style scoped>
+.details-page {
+  padding: 32px;
+  max-width: 1180px;
+  margin: 0 auto;
+}
+
+.back-link {
+  display: inline-block;
+  margin-bottom: 18px;
+  color: #2563eb;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.hero {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 20px;
+  margin-bottom: 22px;
+}
+
+.ticker-pill {
+  display: inline-block;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: #dbeafe;
+  color: #1d4ed8;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.hero h1 {
+  margin: 10px 0 6px;
+  font-size: 32px;
+  color: #0f172a;
+}
+
+.hero p {
+  margin: 0;
+  color: #64748b;
+}
+
+.hero-price {
+  font-size: 42px;
+  font-weight: 800;
+  color: #0f172a;
+}
+
+.hero-price span {
+  display: block;
+  font-size: 14px;
+  font-weight: 600;
+  color: #64748b;
+}
+
+.stats-grid,
+.summary-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 14px;
+  margin-bottom: 24px;
+}
+
+.stat-card,
+.summary-card,
+.panel {
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 16px;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.04);
+}
+
+.stat-card,
+.summary-card {
+  padding: 18px;
+}
+
+.stat-card span,
+.summary-card span {
+  display: block;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #64748b;
+}
+
+.stat-card strong,
+.summary-card strong {
+  display: block;
+  margin-top: 8px;
+  font-size: 20px;
+  color: #0f172a;
+}
+
+.panel {
+  padding: 24px;
+  margin-bottom: 24px;
+}
+
+.panel-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 18px;
+}
+
+.panel-head h2 {
+  margin: 0;
+  color: #0f172a;
+}
+
+.meta-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 14px;
+}
+
+.meta-list li {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 14px;
+  border-radius: 12px;
+  background: #f8fafc;
+}
+
+.meta-list span {
+  color: #64748b;
+}
+
+.meta-list strong {
+  color: #0f172a;
+  text-align: right;
+}
+
+.table-wrap {
+  overflow-x: auto;
+}
+
+.history-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.history-table th,
+.history-table td {
+  padding: 12px 10px;
+  border-bottom: 1px solid #e2e8f0;
+  text-align: left;
+}
+
+.history-table th {
+  font-size: 12px;
+  text-transform: uppercase;
+  color: #64748b;
+}
+
+.positive {
+  color: #15803d;
+  font-weight: 700;
+}
+
+.negative {
+  color: #b91c1c;
+  font-weight: 700;
+}
+
+.empty-state,
+.error-box {
+  padding: 32px;
+  border-radius: 16px;
+  text-align: center;
+}
+
+.empty-state {
+  background: #fff;
+  color: #64748b;
+  border: 1px solid #e2e8f0;
+}
+
+.error-box {
+  background: #fef2f2;
+  color: #b91c1c;
+}
+
+.empty-state h2,
+.error-box h2 {
+  margin: 0 0 10px;
+  color: #0f172a;
+}
+
+.empty-state p,
+.error-box p {
+  margin: 0 0 18px;
+}
+
+.action-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 16px;
+  border-radius: 10px;
+  background: #0f172a;
+  color: #fff;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.action-link-light {
+  background: #b91c1c;
+}
+
+.empty-inline {
+  padding: 22px;
+  border-radius: 12px;
+  background: #f8fafc;
+  color: #64748b;
+  text-align: center;
+}
+
+@media (max-width: 900px) {
+  .hero {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .stats-grid,
+  .summary-grid,
+  .meta-list {
+    grid-template-columns: 1fr;
+  }
+}
+</style>


### PR DESCRIPTION
## Summary
- add Sprint 4 client market pages for securities, security details, and read-only portfolio
- add employee market pages for securities, security details, portfolio, and supervisor-only actuary management
- add route and navigation gating for client trading access and employee actuarial access
- add Cypress coverage for client and employee read-only market flows

## Details
This PR adds the frontend Sprint 4 market foundation while keeping the market area read-only.

It includes:
- client routes and navigation for securities and portfolio
- employee routes and navigation for securities, portfolio, and actuaries management
- market API/store wiring for client and employee portals
- read-only UI for listings, listing details, history, and portfolio
- supervisor-only actuaries management page
- targeted Cypress market smoke tests

It does not add buy/sell actions, orders, approvals, margin, tax tracking, or other Sprint 5 workflows.

## Testing
- `npx cypress run --spec "cypress/e2e/market/client-market.cy.js,cypress/e2e/employee/market.cy.js"`