### PR TITLE
feat(otc): sprint 7 - exercise option contracts via SAGA

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -139,6 +139,12 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
     }
 
+    location /api/v1/otc {
+        proxy_pass http://exchange-service:8088;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+
     # Route loan endpoints to loan-service
     location /api/v1/loans {
         proxy_pass http://loan-service:8089;

--- a/src/api/otc.ts
+++ b/src/api/otc.ts
@@ -87,6 +87,47 @@ export interface CounterOtcOfferPayload {
   premium: number
 }
 
+export type SagaStatus =
+  | 'in_progress'
+  | 'completed'
+  | 'failed'
+  | 'rolling_back'
+  | 'rolled_back'
+  | 'requires_manual_intervention'
+
+export type SagaStepStatus =
+  | 'pending'
+  | 'in_progress'
+  | 'completed'
+  | 'failed'
+  | 'compensated'
+
+export interface SagaStep {
+  stepNumber: number
+  name: string
+  status: SagaStepStatus
+  executedAt?: string
+  errorMessage?: string
+}
+
+export interface SagaTransaction {
+  id: number
+  type: string
+  status: SagaStatus
+  currentStep: number
+  retryCount: number
+  error?: string
+  createdAt: string
+  updatedAt: string
+  steps: SagaStep[]
+}
+
+export interface ExerciseContractResponse {
+  sagaId: number
+  contract?: OtcContract
+  message?: string
+}
+
 export const otcApi = {
   listPublicStocks: () =>
     clientApi.get<{ stocks: PublicOtcStock[]; count: number }>('/otc/public-stocks'),
@@ -115,4 +156,10 @@ export const otcApi = {
 
   cancelOffer: (offerId: number) =>
     clientApi.post<{ offer: OtcOffer }>(`/otc/offers/${offerId}/cancel`),
+
+  exerciseContract: (contractId: number) =>
+    clientApi.post<ExerciseContractResponse>(`/otc/contracts/${contractId}/exercise`),
+
+  getSagaStatus: (sagaId: number) =>
+    clientApi.get<{ saga: SagaTransaction }>(`/otc/saga/${sagaId}`),
 }

--- a/src/stores/otc.ts
+++ b/src/stores/otc.ts
@@ -9,6 +9,7 @@ import {
   type OtcContractStatus,
   type OtcOfferStatus,
   type PublicOtcStock,
+  type SagaTransaction,
 } from '../api/otc'
 
 export const useOtcStore = defineStore('otc', () => {
@@ -23,6 +24,9 @@ export const useOtcStore = defineStore('otc', () => {
   const loadingOffers = ref(false)
   const creatingOffer = ref(false)
   const updatingOffer = ref(false)
+  const exercisingContract = ref(false)
+  const currentSaga = ref<SagaTransaction | null>(null)
+  const sagaError = ref('')
   const error = ref('')
 
   const availablePublicQuantity = computed(() =>
@@ -138,6 +142,64 @@ export const useOtcStore = defineStore('otc', () => {
     }
   }
 
+  async function exerciseContract(contractId: number) {
+    exercisingContract.value = true
+    sagaError.value = ''
+    currentSaga.value = null
+    try {
+      const res = await otcApi.exerciseContract(contractId)
+      const sagaId = res.data.sagaId
+      if (!sagaId) {
+        sagaError.value = res.data.message ?? 'Saga did not start.'
+        throw new Error(sagaError.value)
+      }
+      const saga = await pollSagaUntilDone(sagaId)
+      return { sagaId, saga }
+    } catch (e: any) {
+      const message = e?.response?.data?.message ?? e?.message ?? 'Failed to exercise OTC contract.'
+      sagaError.value = message
+      const sagaId = e?.response?.data?.sagaId
+      if (sagaId) {
+        try {
+          const status = await otcApi.getSagaStatus(sagaId)
+          currentSaga.value = status.data.saga
+        } catch {
+          // ignore secondary failures
+        }
+      }
+      throw e
+    } finally {
+      exercisingContract.value = false
+    }
+  }
+
+  async function pollSagaUntilDone(sagaId: number, maxPolls = 30) {
+    const terminal = new Set([
+      'completed',
+      'failed',
+      'rolled_back',
+      'requires_manual_intervention',
+    ])
+    for (let i = 0; i < maxPolls; i++) {
+      try {
+        const res = await otcApi.getSagaStatus(sagaId)
+        currentSaga.value = res.data.saga
+        if (terminal.has(res.data.saga.status)) {
+          return res.data.saga
+        }
+      } catch {
+        // transient — try again next tick
+      }
+      await new Promise((r) => setTimeout(r, 700))
+    }
+    return currentSaga.value
+  }
+
+  function clearSagaProgress() {
+    currentSaga.value = null
+    sagaError.value = ''
+  }
+
   async function cancelOffer(offerId: number) {
     updatingOffer.value = true
     error.value = ''
@@ -164,6 +226,9 @@ export const useOtcStore = defineStore('otc', () => {
     loadingOffers,
     creatingOffer,
     updatingOffer,
+    exercisingContract,
+    currentSaga,
+    sagaError,
     error,
     availablePublicQuantity,
     validContracts,
@@ -176,5 +241,7 @@ export const useOtcStore = defineStore('otc', () => {
     acceptOffer,
     declineOffer,
     cancelOffer,
+    exerciseContract,
+    clearSagaProgress,
   }
 })

--- a/src/views/client/ClientOtcContractsView.vue
+++ b/src/views/client/ClientOtcContractsView.vue
@@ -1,16 +1,24 @@
 <script setup lang="ts">
-import { computed, onMounted } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import { RouterLink } from 'vue-router'
 import { useOtcStore } from '../../stores/otc'
-import type { OtcContractStatus } from '../../api/otc'
+import { useClientAuthStore } from '../../stores/clientAuth'
+import type { OtcContract, OtcContractStatus } from '../../api/otc'
 
 const otcStore = useOtcStore()
+const authStore = useClientAuthStore()
 const statuses: Array<{ value: OtcContractStatus; label: string }> = [
   { value: '', label: 'Svi' },
   { value: 'valid', label: 'Vazeci' },
   { value: 'expired', label: 'Istekli' },
   { value: 'exercised', label: 'Iskorisceni' },
 ]
+
+const exerciseTarget = ref<OtcContract | null>(null)
+const exerciseError = ref('')
+const exerciseSuccess = ref('')
+
+const currentClientId = computed(() => Number(authStore.client?.id || 0))
 
 const moneyFormatter = new Intl.NumberFormat('en-US', {
   minimumFractionDigits: 2,
@@ -59,6 +67,97 @@ function changeStatus(status: OtcContractStatus) {
   otcStore.fetchContracts(status)
 }
 
+function isBuyer(contract: OtcContract) {
+  return contract.buyerType === 'client' && contract.buyerId === currentClientId.value
+}
+
+function isExercisable(contract: OtcContract) {
+  if (contract.status !== 'valid' || !isBuyer(contract)) return false
+  const settlement = new Date(contract.settlementDate)
+  const today = new Date()
+  today.setHours(0, 0, 0, 0)
+  return settlement >= today
+}
+
+function openExerciseModal(contract: OtcContract) {
+  exerciseTarget.value = contract
+  exerciseError.value = ''
+  exerciseSuccess.value = ''
+  otcStore.clearSagaProgress()
+}
+
+function closeExerciseModal() {
+  exerciseTarget.value = null
+  exerciseError.value = ''
+  otcStore.clearSagaProgress()
+}
+
+async function confirmExercise() {
+  if (!exerciseTarget.value) return
+  const target = exerciseTarget.value
+  exerciseError.value = ''
+  try {
+    await otcStore.exerciseContract(target.id)
+    exerciseSuccess.value = `Ugovor #${target.id} je iskoriscen.`
+    await otcStore.fetchContracts()
+  } catch {
+    exerciseError.value = otcStore.sagaError || 'Iskoriscavanje opcije nije uspelo.'
+  }
+}
+
+function sagaStepLabel(name: string) {
+  switch (name) {
+    case 'reserve_buyer_funds':
+      return '1. Rezervacija sredstava kupca'
+    case 'verify_seller_shares':
+      return '2. Provera hartija prodavca'
+    case 'transfer_funds':
+      return '3. Transfer sredstava'
+    case 'transfer_ownership':
+      return '4. Transfer vlasnistva'
+    case 'finalize_and_consistency_check':
+      return '5. Finalna provera'
+    default:
+      return name
+  }
+}
+
+function sagaStepStatusLabel(status: string) {
+  switch (status) {
+    case 'pending':
+      return 'Ceka'
+    case 'in_progress':
+      return 'U toku'
+    case 'completed':
+      return 'Zavrseno'
+    case 'failed':
+      return 'Neuspesno'
+    case 'compensated':
+      return 'Vraceno'
+    default:
+      return status
+  }
+}
+
+function sagaOverallLabel(status: string) {
+  switch (status) {
+    case 'in_progress':
+      return 'SAGA u toku'
+    case 'completed':
+      return 'SAGA uspesno zavrsena'
+    case 'failed':
+      return 'SAGA neuspesno'
+    case 'rolling_back':
+      return 'SAGA rollback u toku'
+    case 'rolled_back':
+      return 'SAGA vracena'
+    case 'requires_manual_intervention':
+      return 'Potrebna intervencija operatera'
+    default:
+      return status
+  }
+}
+
 onMounted(() => {
   otcStore.fetchContracts()
 })
@@ -89,15 +188,17 @@ onMounted(() => {
       </article>
       <article class="summary-card">
         <span>Izvrsenje opcije</span>
-        <strong>Deferred</strong>
+        <strong>SAGA aktivirana</strong>
       </article>
     </div>
+
+    <div v-if="exerciseSuccess" class="success-box">{{ exerciseSuccess }}</div>
 
     <section class="panel">
       <div class="panel-head">
         <div>
           <h2>Opcioni ugovori</h2>
-          <span class="panel-meta">Ova strana ne pokrece izvrsenje opcije; SAGA flow ostaje za naredni sprint.</span>
+          <span class="panel-meta">Vazeci ugovori za koje je korisnik kupac mogu se iskoristiti dok je settlement datum jos vazeci.</span>
         </div>
         <div class="status-tabs">
           <button
@@ -133,6 +234,7 @@ onMounted(() => {
               <th>Buyer</th>
               <th>Seller</th>
               <th>Kreiran</th>
+              <th>Akcije</th>
             </tr>
           </thead>
           <tbody>
@@ -156,11 +258,90 @@ onMounted(() => {
               <td>#{{ contract.buyerId }} / {{ contract.buyerType }}</td>
               <td>#{{ contract.sellerId }} / {{ contract.sellerType }}</td>
               <td>{{ new Date(contract.createdAt).toLocaleString('sr-RS') }}</td>
+              <td>
+                <button
+                  v-if="isExercisable(contract)"
+                  class="exercise-btn"
+                  @click="openExerciseModal(contract)"
+                >
+                  Iskoristi
+                </button>
+                <span v-else class="asset-meta">-</span>
+              </td>
             </tr>
           </tbody>
         </table>
       </div>
     </section>
+
+    <div v-if="exerciseTarget" class="modal-backdrop" @click.self="closeExerciseModal">
+      <section class="exercise-modal">
+        <div class="modal-head">
+          <div>
+            <p class="eyebrow">Iskoriscavanje opcije</p>
+            <h2>#{{ exerciseTarget.id }} / {{ exerciseTarget.ticker }}</h2>
+            <span>SAGA pokrece 5 koraka i automatski se rollback-uje na gresci.</span>
+          </div>
+          <button class="close-btn" @click="closeExerciseModal" :disabled="otcStore.exercisingContract">x</button>
+        </div>
+
+        <div class="exercise-summary">
+          <div><span>Kolicina</span><strong>{{ fmtQuantity(exerciseTarget.amount) }}</strong></div>
+          <div><span>Strike cena</span><strong>{{ fmtMoney(exerciseTarget.strikePrice) }} {{ exerciseTarget.exchange.currency }}</strong></div>
+          <div><span>Trzisna cena</span><strong>{{ fmtMoney(exerciseTarget.currentPrice) }} {{ exerciseTarget.exchange.currency }}</strong></div>
+          <div><span>Premija</span><strong>{{ fmtMoney(exerciseTarget.premium) }} {{ exerciseTarget.exchange.currency }}</strong></div>
+          <div>
+            <span>Procenjeni profit</span>
+            <strong :class="profitClass(exerciseTarget.profit)">
+              {{ fmtMoney(exerciseTarget.profit) }} {{ exerciseTarget.exchange.currency }}
+            </strong>
+          </div>
+          <div><span>Settlement</span><strong>{{ new Date(exerciseTarget.settlementDate).toLocaleDateString('sr-RS') }}</strong></div>
+        </div>
+
+        <div v-if="otcStore.currentSaga" class="saga-progress">
+          <div class="saga-overall">
+            <span>Status:</span>
+            <strong :class="`saga-status saga-${otcStore.currentSaga.status}`">
+              {{ sagaOverallLabel(otcStore.currentSaga.status) }}
+            </strong>
+          </div>
+          <ol class="saga-steps">
+            <li
+              v-for="step in otcStore.currentSaga.steps"
+              :key="step.stepNumber"
+              :class="`saga-step saga-step-${step.status}`"
+            >
+              <span class="saga-step-name">{{ sagaStepLabel(step.name) }}</span>
+              <span class="saga-step-status">{{ sagaStepStatusLabel(step.status) }}</span>
+              <span v-if="step.errorMessage" class="saga-step-error">{{ step.errorMessage }}</span>
+            </li>
+          </ol>
+        </div>
+
+        <div v-if="exerciseError" class="error-box">{{ exerciseError }}</div>
+
+        <div class="modal-actions">
+          <button
+            type="button"
+            class="secondary-btn"
+            @click="closeExerciseModal"
+            :disabled="otcStore.exercisingContract"
+          >
+            Zatvori
+          </button>
+          <button
+            v-if="!exerciseSuccess && (!otcStore.currentSaga || otcStore.currentSaga.status === 'in_progress' || otcStore.currentSaga.status === 'rolling_back')"
+            type="button"
+            class="submit-btn"
+            :disabled="otcStore.exercisingContract"
+            @click="confirmExercise"
+          >
+            {{ otcStore.exercisingContract ? 'Pokrecem SAGA...' : 'Pokreni iskoriscavanje' }}
+          </button>
+        </div>
+      </section>
+    </div>
   </div>
 </template>
 
@@ -392,13 +573,255 @@ onMounted(() => {
   color: #1d4ed8;
 }
 
+.exercise-btn {
+  border: none;
+  border-radius: 10px;
+  background: #0f172a;
+  color: #fff;
+  cursor: pointer;
+  padding: 7px 12px;
+  font-weight: 800;
+}
+
+.exercise-btn:hover {
+  background: #1e293b;
+}
+
+.success-box {
+  border-radius: 12px;
+  margin-bottom: 18px;
+  padding: 14px 18px;
+  color: #166534;
+  background: #dcfce7;
+  border: 1px solid #bbf7d0;
+}
+
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: rgba(15, 23, 42, 0.45);
+}
+
+.exercise-modal {
+  width: min(640px, 100%);
+  max-height: calc(100vh - 48px);
+  overflow: auto;
+  border-radius: 20px;
+  background: #fff;
+  box-shadow: 0 24px 70px rgba(15, 23, 42, 0.25);
+  padding: 24px;
+}
+
+.modal-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 18px;
+}
+
+.modal-head h2 {
+  margin: 0;
+  color: #0f172a;
+}
+
+.modal-head span {
+  display: block;
+  margin-top: 6px;
+  color: #64748b;
+}
+
+.close-btn {
+  width: 32px;
+  height: 32px;
+  border: none;
+  border-radius: 10px;
+  background: #f1f5f9;
+  color: #475569;
+  cursor: pointer;
+  font-weight: 800;
+}
+
+.close-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.exercise-summary {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  border-radius: 14px;
+  background: #f8fafc;
+  padding: 14px 16px;
+  margin-bottom: 16px;
+}
+
+.exercise-summary span {
+  display: block;
+  color: #64748b;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.exercise-summary strong {
+  display: block;
+  margin-top: 4px;
+  color: #0f172a;
+  font-size: 15px;
+}
+
+.saga-progress {
+  border: 1px solid #e2e8f0;
+  border-radius: 14px;
+  padding: 14px 16px;
+  margin-bottom: 16px;
+  background: #ffffff;
+}
+
+.saga-overall {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 12px;
+  color: #475569;
+  font-size: 13px;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.saga-status {
+  font-size: 13px;
+  font-weight: 800;
+}
+
+.saga-in_progress {
+  color: #1d4ed8;
+}
+
+.saga-completed {
+  color: #166534;
+}
+
+.saga-failed,
+.saga-requires_manual_intervention {
+  color: #991b1b;
+}
+
+.saga-rolling_back,
+.saga-rolled_back {
+  color: #b45309;
+}
+
+.saga-steps {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 8px;
+}
+
+.saga-step {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 4px 12px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  background: #f8fafc;
+  border-left: 3px solid #cbd5e1;
+}
+
+.saga-step-pending {
+  border-left-color: #cbd5e1;
+}
+
+.saga-step-in_progress {
+  border-left-color: #2563eb;
+  background: #eff6ff;
+}
+
+.saga-step-completed {
+  border-left-color: #16a34a;
+  background: #f0fdf4;
+}
+
+.saga-step-failed {
+  border-left-color: #dc2626;
+  background: #fef2f2;
+}
+
+.saga-step-compensated {
+  border-left-color: #d97706;
+  background: #fffbeb;
+}
+
+.saga-step-name {
+  font-weight: 800;
+  color: #0f172a;
+  font-size: 14px;
+}
+
+.saga-step-status {
+  font-weight: 800;
+  font-size: 12px;
+  color: #475569;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.saga-step-error {
+  grid-column: 1 / -1;
+  font-size: 12px;
+  color: #991b1b;
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+.secondary-btn,
+.submit-btn {
+  border: none;
+  border-radius: 10px;
+  cursor: pointer;
+  font-weight: 800;
+  padding: 10px 16px;
+}
+
+.secondary-btn {
+  background: #f1f5f9;
+  color: #475569;
+}
+
+.submit-btn {
+  background: #0f172a;
+  color: #fff;
+}
+
+.submit-btn:disabled,
+.secondary-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
 @media (max-width: 900px) {
   .page-header,
   .panel-head {
     flex-direction: column;
   }
 
-  .summary-grid {
+  .summary-grid,
+  .exercise-summary {
     grid-template-columns: 1fr;
   }
 }


### PR DESCRIPTION
ClientOtcContractsView now shows an "Iskoristi" button for valid contracts where the caller is the buyer and the settlement window is still open. The exercise modal displays strike/market/profit summary and live SAGA progress (5 steps with per-step status pills) by polling the new GET /api/v1/otc/saga/:id endpoint.

Adds nginx route for /api/v1/otc so OTC requests reach exchange-service:8088 instead of falling through to backend:8080.