### PR TITLE
feat(funds): sprint 8 investment-fund frontend

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -145,6 +145,12 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
     }
 
+    location /api/v1/funds {
+        proxy_pass http://exchange-service:8088;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+
     # Route loan endpoints to loan-service
     location /api/v1/loans {
         proxy_pass http://loan-service:8089;

--- a/src/api/fund.ts
+++ b/src/api/fund.ts
@@ -1,0 +1,120 @@
+// Fund API — works against both the employee token (sessionStorage.access_token)
+// and the client token (sessionStorage.client_access_token). The choice is made
+// by which axios instance the caller imports.
+
+import employeeApi from './client'
+import clientApi from './clientAuth'
+
+export interface FundSummary {
+  id: number
+  naziv: string
+  opis: string
+  minimalniUlog: number
+  managerId: number
+  accountId: number
+  datumKreiranja: string
+  fundValueRSD: number
+  liquidCashRSD: number
+  holdingsValueRSD: number
+  totalInvestedRSD: number
+  profitRSD: number
+  participantsCount: number
+  withdrawalCommRate: number
+}
+
+export interface FundHolding {
+  id: number
+  assetId: number
+  ticker: string
+  name: string
+  price: number
+  change: number
+  volume: number
+  quantity: number
+  avgBuyPrice: number
+  acquisitionDate: string
+  initialMarginCost: number
+}
+
+export interface FundPerformancePoint {
+  date: string
+  fundValue: number
+}
+
+export interface FundPositionView {
+  fundId: number
+  naziv: string
+  ukupanUlozeniRSD: number
+  udeoProcenat: number
+  trenutnaVrednost: number
+  profitRSD: number
+  fundValueRSD: number
+}
+
+export interface InvestInFundPayload {
+  sourceAccountId: number
+  amount: number
+  asBank?: boolean
+}
+
+export interface WithdrawFromFundPayload {
+  destinationAccountId: number
+  amount?: number
+  withdrawAll?: boolean
+  asBank?: boolean
+}
+
+export interface CreateFundPayload {
+  naziv: string
+  opis: string
+  minimalniUlog: number
+}
+
+export interface WithdrawResult {
+  grossWithdrawn: number
+  commission: number
+  netToAccount: number
+  liquidated: boolean
+  liquidatedItems: Array<{
+    assetId: number
+    ticker: string
+    quantity: number
+    pricePerRSD: number
+    totalRSD: number
+  }>
+}
+
+function fundApiFor(axiosInstance: typeof employeeApi) {
+  return {
+    list: () => axiosInstance.get<{ funds: FundSummary[]; count: number }>('/funds'),
+    get: (id: number) => axiosInstance.get<{ fund: FundSummary }>(`/funds/${id}`),
+    holdings: (id: number) =>
+      axiosInstance.get<{ holdings: FundHolding[]; count: number }>(`/funds/${id}/holdings`),
+    performance: (id: number, granularity: 'monthly' | 'quarterly' | 'yearly' | 'all' = 'monthly') =>
+      axiosInstance.get<{ performance: FundPerformancePoint[]; count: number; granularity: string }>(
+        `/funds/${id}/performance`,
+        { params: { granularity } },
+      ),
+    invest: (fundId: number, payload: InvestInFundPayload) =>
+      axiosInstance.post(`/funds/${fundId}/invest`, payload),
+    withdraw: (fundId: number, payload: WithdrawFromFundPayload) =>
+      axiosInstance.post<WithdrawResult>(`/funds/${fundId}/withdraw`, payload),
+    create: (payload: CreateFundPayload) =>
+      axiosInstance.post<{ fund: FundSummary }>('/funds', payload),
+    mine: () =>
+      axiosInstance.get<{
+        funds?: FundSummary[]
+        positions?: FundPositionView[]
+        count: number
+        role: 'client' | 'supervisor'
+      }>('/funds/positions/mine'),
+    transferOwnership: (oldManagerId: number, newManagerId: number) =>
+      axiosInstance.post<{ reassigned: number }>('/funds/transfer-ownership', {
+        oldManagerId,
+        newManagerId,
+      }),
+  }
+}
+
+export const fundApi = fundApiFor(employeeApi)
+export const clientFundApi = fundApiFor(clientApi)

--- a/src/api/order.ts
+++ b/src/api/order.ts
@@ -21,6 +21,9 @@ export interface CreateOrderPayload {
   isMargin?: boolean
   accountId: number
   afterHours?: boolean
+  // Set when a supervisor places a buy order on behalf of an investment fund;
+  // the backend rewrites the order owner from the bank to the fund.
+  fundId?: number
 }
 
 export interface Order {

--- a/src/components/BuyOrderModal.vue
+++ b/src/components/BuyOrderModal.vue
@@ -5,6 +5,8 @@ import type { CreateOrderPayload, OrderType } from '../api/order'
 import { clientAccountApi } from '../api/clientAccount'
 import { accountApi } from '../api/account'
 import { useClientAuthStore } from '../stores/clientAuth'
+import { useAuthStore } from '../stores/auth'
+import { fundApi, type FundSummary } from '../api/fund'
 import type { ListingItem } from '../api/market'
 
 // ---------------------------------------------------------------------------
@@ -39,9 +41,30 @@ interface AccountOption {
 }
 
 const clientAuth = useClientAuthStore()
+const employeeAuth = useAuthStore()
 
 const accounts = ref<AccountOption[]>([])
 const accountsLoading = ref(false)
+
+// --- Fund buy support (FOND-BE-8 / FOND-FE-16) -------------------------------
+// Supervisor employees can choose to place a buy order on behalf of an
+// investment fund instead of the bank. When `forSelection === 'fund'`, the
+// account list is replaced with the selected fund's RSD account and the
+// fundId is forwarded to the order create endpoint.
+type ForSelection = 'bank' | 'fund'
+const forSelection = ref<ForSelection>('bank')
+const funds = ref<FundSummary[]>([])
+const fundsLoading = ref(false)
+const selectedFundId = ref<number | null>(null)
+const isEmployeeBuy = computed(() =>
+  props.userType === 'employee' && props.direction === 'buy',
+)
+const canPickFund = computed(() =>
+  isEmployeeBuy.value && employeeAuth.hasPermission?.('employeeSupervisor'),
+)
+const selectedFund = computed(() =>
+  funds.value.find((f) => f.id === selectedFundId.value) ?? null,
+)
 
 // Form fields
 const quantity = ref(1)
@@ -211,6 +234,10 @@ async function submitOrder() {
       accountId: selectedAccountId.value,
       afterHours: afterHours.value,
     }
+    if (isEmployeeBuy.value && forSelection.value === 'fund' && selectedFundId.value) {
+      payload.fundId = selectedFundId.value
+      payload.accountId = selectedFund.value?.accountId ?? selectedAccountId.value
+    }
     if (props.userType === 'client') {
       await clientOrderApi.createOrder(payload)
     } else {
@@ -226,7 +253,34 @@ async function submitOrder() {
   }
 }
 
-onMounted(loadAccounts)
+async function loadFunds() {
+  if (!canPickFund.value) return
+  fundsLoading.value = true
+  try {
+    const res = await fundApi.list()
+    funds.value = res.data?.funds ?? []
+    if (funds.value.length > 0 && selectedFundId.value === null) {
+      selectedFundId.value = funds.value[0]!.id
+    }
+  } catch {
+    // Non-fatal — fund radio simply stays disabled.
+  } finally {
+    fundsLoading.value = false
+  }
+}
+
+// When the supervisor flips to "Za fond", swap the visible account to the
+// fund's RSD account so the user sees and submits the correct one.
+watch([forSelection, selectedFundId], () => {
+  if (forSelection.value === 'fund' && selectedFund.value) {
+    selectedAccountId.value = selectedFund.value.accountId
+  }
+})
+
+onMounted(async () => {
+  await loadAccounts()
+  await loadFunds()
+})
 </script>
 
 <template>
@@ -294,6 +348,34 @@ onMounted(loadAccounts)
           <div v-if="needsStop || orderType === 'market'" class="field">
             <label>Stop vrednost ({{ listing.exchange.currency }}){{ needsStop ? '' : ' — opciono' }}</label>
             <input type="number" v-model.number="stopValue" min="0.01" step="0.01" placeholder="0.00" />
+          </div>
+
+          <!-- Buyer selector (supervisor only) -->
+          <div v-if="canPickFund" class="field field-full">
+            <label>Kupac</label>
+            <div class="for-radio-group">
+              <label class="for-radio-label">
+                <input type="radio" value="bank" v-model="forSelection" />
+                <span>Za banku</span>
+              </label>
+              <label class="for-radio-label">
+                <input type="radio" value="fund" v-model="forSelection" :disabled="funds.length === 0" />
+                <span>Za investicioni fond</span>
+              </label>
+            </div>
+            <div v-if="forSelection === 'fund'" class="fund-picker">
+              <select v-model.number="selectedFundId" :disabled="fundsLoading || funds.length === 0">
+                <option v-if="fundsLoading" :value="null" disabled>Učitavam fondove...</option>
+                <option v-else-if="funds.length === 0" :value="null" disabled>Nema fondova</option>
+                <option v-for="f in funds" :key="f.id" :value="f.id">
+                  {{ f.naziv }} — likvidnost {{ f.liquidCashRSD.toFixed(2) }} RSD
+                </option>
+              </select>
+              <p v-if="selectedFund" class="field-hint">
+                Vrednost fonda {{ selectedFund.fundValueRSD.toFixed(2) }} RSD,
+                profit {{ selectedFund.profitRSD.toFixed(2) }} RSD.
+              </p>
+            </div>
           </div>
 
           <!-- Account -->
@@ -670,4 +752,12 @@ onMounted(loadAccounts)
 }
 .btn-sell:hover:not(:disabled) { background: #b91c1c; }
 .btn-sell:disabled { opacity: 0.5; cursor: not-allowed; }
+
+.for-radio-group { display: flex; gap: 16px; padding: 4px 0; }
+.for-radio-label { display: flex; align-items: center; gap: 6px; cursor: pointer; font-size: 14px; color: #0f172a; }
+.fund-picker { margin-top: 8px; }
+.fund-picker select {
+  width: 100%; padding: 9px 12px; border: 1px solid #cbd5e1; border-radius: 8px;
+  font-size: 14px; color: #0f172a; background: #fff;
+}
 </style>

--- a/src/router/clientRoutes.ts
+++ b/src/router/clientRoutes.ts
@@ -51,6 +51,14 @@ export const clientRoutes: RouteRecordRaw[] = [
         meta: { clientTradingOnly: true },
       },
       {
+        path: 'funds',
+        component: () => import('../views/client/ClientFundsView.vue'),
+      },
+      {
+        path: 'funds/:id(\\d+)',
+        component: () => import('../views/client/ClientFundDetailView.vue'),
+      },
+      {
         path: 'prenos',
         component: () => import('../views/client/ClientPrenosView.vue'),
       },

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -84,6 +84,19 @@ const router = createRouter({
           meta: { employeeSupervisorOnly: true },
         },
         {
+          path: 'funds',
+          component: () => import('../views/EmployeeFundsView.vue'),
+        },
+        {
+          path: 'funds/new',
+          component: () => import('../views/EmployeeCreateFundView.vue'),
+          meta: { employeeSupervisorOnly: true },
+        },
+        {
+          path: 'funds/:id(\\d+)',
+          component: () => import('../views/EmployeeFundDetailView.vue'),
+        },
+        {
           path: 'loans/requests',
           component: () => import('../views/LoanRequestsView.vue'),
         },

--- a/src/views/EmployeeCreateFundView.vue
+++ b/src/views/EmployeeCreateFundView.vue
@@ -1,0 +1,86 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { fundApi } from '../api/fund'
+
+const router = useRouter()
+
+const naziv = ref('')
+const opis = ref('')
+const minimalniUlog = ref<number>(10000)
+const submitting = ref(false)
+const errorMsg = ref('')
+
+async function submit() {
+  errorMsg.value = ''
+  if (!naziv.value.trim()) { errorMsg.value = 'Unesite naziv fonda.'; return }
+  if (minimalniUlog.value <= 0) { errorMsg.value = 'Minimalni ulog mora biti pozitivan.'; return }
+
+  submitting.value = true
+  try {
+    const res = await fundApi.create({
+      naziv: naziv.value.trim(),
+      opis: opis.value.trim(),
+      minimalniUlog: minimalniUlog.value,
+    })
+    const id = res.data?.fund?.id
+    if (id) router.push(`/funds/${id}`)
+    else router.push('/funds')
+  } catch (err: any) {
+    errorMsg.value = err?.response?.data?.message ?? 'Greska pri kreiranju fonda.'
+  } finally {
+    submitting.value = false
+  }
+}
+</script>
+
+<template>
+  <div class="create-fund">
+    <button class="back-btn" @click="router.push('/funds')">&larr; Nazad</button>
+    <header><h1>Kreiranje investicionog fonda</h1></header>
+
+    <div v-if="errorMsg" class="error-box">{{ errorMsg }}</div>
+
+    <form class="card" @submit.prevent="submit">
+      <div class="field">
+        <label>Naziv fonda <span class="req">*</span></label>
+        <input type="text" v-model="naziv" placeholder="npr. EXBanka Plavi Fond" />
+        <p class="hint">Mora biti unikatan.</p>
+      </div>
+      <div class="field">
+        <label>Kratak opis</label>
+        <textarea v-model="opis" rows="4" placeholder="Kratak opis investicione strategije fonda..."></textarea>
+      </div>
+      <div class="field">
+        <label>Minimalni iznos ulaganja (RSD) <span class="req">*</span></label>
+        <input type="number" v-model.number="minimalniUlog" min="0" step="0.01" />
+      </div>
+
+      <div class="hint">
+        Po zavrsetku fond ce odmah biti vidljiv na Discovery stranici. Banka ce
+        automatski kreirati dinarski racun namenjen ovom fondu.
+      </div>
+
+      <div class="actions">
+        <button type="button" class="btn-secondary" :disabled="submitting" @click="router.push('/funds')">Otkazi</button>
+        <button type="submit" class="btn-primary" :disabled="submitting">{{ submitting ? 'Slanje...' : 'Kreiraj fond' }}</button>
+      </div>
+    </form>
+  </div>
+</template>
+
+<style scoped>
+.create-fund { padding: 32px; max-width: 720px; margin: 0 auto; }
+.back-btn { background: none; border: none; color: #2563eb; font-size: 14px; cursor: pointer; margin-bottom: 16px; }
+header h1 { margin: 0 0 16px; color: #0f172a; }
+.card { background: #fff; border-radius: 16px; padding: 24px; box-shadow: 0 2px 12px rgba(15,23,42,0.05); }
+.field { display: flex; flex-direction: column; gap: 5px; margin-bottom: 16px; }
+.field label { font-size: 12px; font-weight: 600; color: #475569; text-transform: uppercase; letter-spacing: 0.04em; }
+.field input, .field textarea { padding: 10px 12px; border: 1px solid #cbd5e1; border-radius: 10px; font-size: 14px; font-family: inherit; }
+.req { color: #dc2626; }
+.hint { color: #64748b; font-size: 13px; margin: 4px 0 8px; }
+.actions { display: flex; gap: 10px; justify-content: flex-end; margin-top: 16px; }
+.btn-primary { padding: 10px 22px; border: none; border-radius: 10px; background: #2563eb; color: #fff; font-weight: 700; cursor: pointer; }
+.btn-secondary { padding: 10px 22px; border: 1px solid #cbd5e1; border-radius: 10px; background: #fff; color: #374151; font-weight: 600; cursor: pointer; }
+.error-box { background: #fef2f2; border: 1px solid #fca5a5; border-radius: 10px; padding: 10px 14px; color: #b91c1c; margin-bottom: 14px; }
+</style>

--- a/src/views/EmployeeFundDetailView.vue
+++ b/src/views/EmployeeFundDetailView.vue
@@ -1,0 +1,269 @@
+<script setup lang="ts">
+import { computed, onMounted, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { Line } from 'vue-chartjs'
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Title,
+  Tooltip,
+  Filler,
+  type ChartData,
+  type ChartOptions,
+} from 'chart.js'
+import {
+  fundApi,
+  type FundSummary,
+  type FundHolding,
+  type FundPerformancePoint,
+} from '../api/fund'
+import { accountApi } from '../api/account'
+import { useAuthStore } from '../stores/auth'
+
+ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Title, Tooltip, Filler)
+
+const route = useRoute()
+const router = useRouter()
+const auth = useAuthStore()
+const fundId = computed(() => Number(route.params.id))
+
+const fund = ref<FundSummary | null>(null)
+const holdings = ref<FundHolding[]>([])
+const performance = ref<FundPerformancePoint[]>([])
+const granularity = ref<'monthly' | 'quarterly' | 'yearly'>('monthly')
+const loading = ref(false)
+const errorMsg = ref('')
+
+const isSupervisor = computed(() => auth.hasPermission('employeeSupervisor'))
+const isManager = computed(() => isSupervisor.value && fund.value?.managerId === auth.employee?.id)
+
+// Bank-invest dialog (supervisor on bank's behalf)
+const investOpen = ref(false)
+const investAmount = ref(0)
+const bankAccounts = ref<Array<{ id: number; label: string }>>([])
+const investAccountId = ref<number | null>(null)
+const dialogBusy = ref(false)
+const dialogError = ref('')
+
+async function load() {
+  loading.value = true
+  errorMsg.value = ''
+  try {
+    const [fundRes, holdingsRes, perfRes] = await Promise.all([
+      fundApi.get(fundId.value),
+      fundApi.holdings(fundId.value),
+      fundApi.performance(fundId.value, granularity.value),
+    ])
+    fund.value = fundRes.data?.fund ?? null
+    holdings.value = holdingsRes.data?.holdings ?? []
+    performance.value = perfRes.data?.performance ?? []
+  } catch (err: any) {
+    errorMsg.value = err?.response?.data?.message ?? 'Greska pri ucitavanju fonda.'
+  } finally {
+    loading.value = false
+  }
+}
+
+async function loadBankAccounts() {
+  try {
+    const res = await accountApi.listAll({ status: 'aktivan', pageSize: 200 })
+    const items: any[] = res.data?.accounts ?? res.data?.content ?? res.data ?? []
+    bankAccounts.value = items
+      .filter((a: any) =>
+        (!a.clientId || a.clientId === '0' || a.clientId === 0) &&
+        (a.currencyKod === 'RSD' || a.currency?.kod === 'RSD'),
+      )
+      .map((a: any) => ({ id: Number(a.id), label: `${a.naziv || a.brojRacuna}` }))
+    if (bankAccounts.value.length > 0 && investAccountId.value === null) {
+      investAccountId.value = bankAccounts.value[0]!.id
+    }
+  } catch {
+    // ignore
+  }
+}
+
+watch(granularity, async () => {
+  try {
+    const res = await fundApi.performance(fundId.value, granularity.value)
+    performance.value = res.data?.performance ?? []
+  } catch {
+    // ignore
+  }
+})
+
+async function submitInvestForBank() {
+  if (!investAccountId.value || investAmount.value <= 0) return
+  dialogBusy.value = true
+  dialogError.value = ''
+  try {
+    await fundApi.invest(fundId.value, {
+      sourceAccountId: investAccountId.value,
+      amount: investAmount.value,
+      asBank: true,
+    })
+    investOpen.value = false
+    investAmount.value = 0
+    await load()
+  } catch (err: any) {
+    dialogError.value = err?.response?.data?.message ?? 'Greska pri uplati.'
+  } finally {
+    dialogBusy.value = false
+  }
+}
+
+const chartData = computed<ChartData<'line'>>(() => ({
+  labels: performance.value.map((p) => p.date),
+  datasets: [
+    {
+      label: 'Vrednost fonda (RSD)',
+      data: performance.value.map((p) => p.fundValue),
+      borderColor: '#2563eb',
+      backgroundColor: 'rgba(37,99,235,0.08)',
+      borderWidth: 2,
+      pointRadius: 3,
+      fill: true,
+      tension: 0.3,
+    },
+  ],
+}))
+const chartOptions: ChartOptions<'line'> = {
+  responsive: true,
+  maintainAspectRatio: false,
+  plugins: { legend: { display: false }, tooltip: { enabled: true } },
+  scales: { x: { grid: { display: false } }, y: { ticks: { callback: (v: any) => `${Number(v).toLocaleString()}` } } },
+}
+
+onMounted(async () => {
+  await load()
+  await loadBankAccounts()
+})
+</script>
+
+<template>
+  <div class="fund-detail">
+    <button class="back-btn" @click="router.push('/funds')">&larr; Nazad na fondove</button>
+
+    <div v-if="errorMsg" class="error-box">{{ errorMsg }}</div>
+    <div v-if="loading" class="hint">Ucitavam...</div>
+
+    <template v-else-if="fund">
+      <header class="card">
+        <h1>{{ fund.naziv }}</h1>
+        <p class="muted">{{ fund.opis }}</p>
+        <div class="kpi-grid">
+          <div class="kpi"><span>Vrednost</span><strong>{{ fund.fundValueRSD.toFixed(2) }} RSD</strong></div>
+          <div class="kpi"><span>Likvidnost</span><strong>{{ fund.liquidCashRSD.toFixed(2) }} RSD</strong></div>
+          <div class="kpi"><span>Vrednost hartija</span><strong>{{ fund.holdingsValueRSD.toFixed(2) }} RSD</strong></div>
+          <div class="kpi"><span>Profit</span><strong :class="fund.profitRSD >= 0 ? 'positive' : 'negative'">{{ fund.profitRSD.toFixed(2) }} RSD</strong></div>
+          <div class="kpi"><span>Min. ulog</span><strong>{{ fund.minimalniUlog.toFixed(2) }} RSD</strong></div>
+          <div class="kpi"><span>Ucesnika</span><strong>{{ fund.participantsCount }}</strong></div>
+          <div class="kpi"><span>Menadzer (ID)</span><strong>{{ fund.managerId }}</strong></div>
+          <div class="kpi"><span>Racun fonda (ID)</span><strong>{{ fund.accountId }}</strong></div>
+        </div>
+        <div v-if="isSupervisor" class="actions">
+          <button class="btn-primary" @click="investOpen = true">Uplati za banku</button>
+          <button v-if="isManager" class="btn-secondary" @click="router.push('/securities')">Kupi hartiju za fond</button>
+        </div>
+      </header>
+
+      <section class="card">
+        <div class="section-header">
+          <h2>Performanse fonda</h2>
+          <select v-model="granularity">
+            <option value="monthly">Mesecno</option>
+            <option value="quarterly">Kvartalno</option>
+            <option value="yearly">Godisnje</option>
+          </select>
+        </div>
+        <div class="chart-wrapper">
+          <Line v-if="performance.length > 0" :data="chartData" :options="chartOptions" />
+          <p v-else class="hint">Nema istorijskih podataka.</p>
+        </div>
+      </section>
+
+      <section class="card">
+        <h2>Hartije u fondu</h2>
+        <table v-if="holdings.length > 0" class="data-table">
+          <thead>
+            <tr>
+              <th>Ticker</th><th>Naziv</th>
+              <th class="num">Cena</th><th class="num">Volume</th>
+              <th class="num">Kolicina</th><th class="num">Pros. cena kupovine</th>
+              <th>Datum sticanja</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="h in holdings" :key="h.id">
+              <td><strong>{{ h.ticker }}</strong></td>
+              <td>{{ h.name }}</td>
+              <td class="num">{{ h.price.toFixed(2) }}</td>
+              <td class="num">{{ h.volume.toLocaleString() }}</td>
+              <td class="num">{{ h.quantity.toFixed(2) }}</td>
+              <td class="num">{{ h.avgBuyPrice.toFixed(2) }}</td>
+              <td>{{ h.acquisitionDate }}</td>
+            </tr>
+          </tbody>
+        </table>
+        <p v-else class="hint">Fond jos uvek nema hartija.</p>
+      </section>
+    </template>
+
+    <!-- Invest-for-bank modal -->
+    <div v-if="investOpen" class="modal-overlay" @click.self="investOpen = false">
+      <div class="modal-box">
+        <h2>Uplata za banku</h2>
+        <div v-if="dialogError" class="error-box">{{ dialogError }}</div>
+        <div class="field">
+          <label>Bankin racun (RSD)</label>
+          <select v-model.number="investAccountId">
+            <option v-for="a in bankAccounts" :key="a.id" :value="a.id">{{ a.label }}</option>
+          </select>
+        </div>
+        <div class="field">
+          <label>Iznos (min. {{ fund?.minimalniUlog.toFixed(2) }} RSD)</label>
+          <input type="number" v-model.number="investAmount" min="0" step="0.01" />
+        </div>
+        <div class="modal-actions">
+          <button class="btn-secondary" :disabled="dialogBusy" @click="investOpen = false">Otkazi</button>
+          <button class="btn-primary" :disabled="dialogBusy" @click="submitInvestForBank">{{ dialogBusy ? 'Slanje...' : 'Uplati' }}</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.fund-detail { padding: 32px; max-width: 1200px; margin: 0 auto; }
+.back-btn { background: none; border: none; color: #2563eb; font-size: 14px; cursor: pointer; margin-bottom: 16px; }
+.card { background: #fff; border-radius: 16px; padding: 24px; box-shadow: 0 2px 12px rgba(15,23,42,0.05); margin-bottom: 24px; }
+.card h1 { margin: 0 0 6px; color: #0f172a; font-size: 26px; }
+.card h2 { margin: 0 0 16px; color: #0f172a; font-size: 18px; }
+.muted { color: #64748b; margin: 0 0 20px; }
+.kpi-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 14px; margin-bottom: 20px; }
+.kpi { background: #f8fafc; padding: 14px; border-radius: 12px; }
+.kpi span { display: block; color: #64748b; font-size: 12px; text-transform: uppercase; letter-spacing: 0.04em; margin-bottom: 4px; }
+.kpi strong { font-size: 18px; color: #0f172a; }
+.actions { display: flex; gap: 10px; }
+.section-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 16px; }
+.section-header select { padding: 7px 12px; border: 1px solid #cbd5e1; border-radius: 8px; font-size: 13px; }
+.chart-wrapper { position: relative; height: 320px; }
+.data-table { width: 100%; border-collapse: collapse; }
+.data-table th, .data-table td { padding: 10px 8px; border-bottom: 1px solid #f1f5f9; text-align: left; font-size: 14px; }
+.data-table th { color: #64748b; font-size: 12px; text-transform: uppercase; letter-spacing: 0.04em; }
+.data-table .num { text-align: right; font-variant-numeric: tabular-nums; }
+.positive { color: #16a34a; }
+.negative { color: #dc2626; }
+.btn-primary { padding: 9px 18px; border: none; border-radius: 10px; background: #2563eb; color: #fff; font-weight: 600; cursor: pointer; }
+.btn-secondary { padding: 9px 18px; border: 1px solid #cbd5e1; border-radius: 10px; background: #fff; color: #374151; font-weight: 600; cursor: pointer; }
+.error-box { background: #fef2f2; border: 1px solid #fca5a5; border-radius: 10px; padding: 10px 14px; color: #b91c1c; margin-bottom: 14px; }
+.hint { color: #64748b; text-align: center; padding: 20px 0; }
+.modal-overlay { position: fixed; inset: 0; background: rgba(15,23,42,0.45); display: flex; align-items: center; justify-content: center; z-index: 1000; padding: 16px; }
+.modal-box { background: #fff; border-radius: 18px; padding: 24px; width: 100%; max-width: 480px; }
+.field { display: flex; flex-direction: column; gap: 5px; margin-bottom: 14px; }
+.field label { font-size: 12px; font-weight: 600; color: #475569; text-transform: uppercase; letter-spacing: 0.04em; }
+.field input, .field select { padding: 9px 12px; border: 1px solid #cbd5e1; border-radius: 8px; font-size: 14px; }
+.modal-actions { display: flex; gap: 10px; justify-content: flex-end; margin-top: 12px; }
+</style>

--- a/src/views/EmployeeFundsView.vue
+++ b/src/views/EmployeeFundsView.vue
@@ -1,0 +1,147 @@
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { fundApi, type FundSummary } from '../api/fund'
+import { useAuthStore } from '../stores/auth'
+
+const router = useRouter()
+const auth = useAuthStore()
+
+const isSupervisor = computed(() => auth.hasPermission('employeeSupervisor'))
+
+const activeTab = ref<'all' | 'mine'>('all')
+const funds = ref<FundSummary[]>([])
+const myFunds = ref<FundSummary[]>([])
+const loading = ref(false)
+const errorMsg = ref('')
+
+const search = ref('')
+const sortKey = ref<'naziv' | 'value' | 'profit' | 'minimalni'>('naziv')
+
+const filtered = computed(() => {
+  let rows = activeTab.value === 'mine' ? [...myFunds.value] : [...funds.value]
+  if (search.value.trim()) {
+    const q = search.value.toLowerCase()
+    rows = rows.filter((f) => f.naziv.toLowerCase().includes(q) || f.opis.toLowerCase().includes(q))
+  }
+  rows.sort((a, b) => {
+    switch (sortKey.value) {
+      case 'value': return b.fundValueRSD - a.fundValueRSD
+      case 'profit': return b.profitRSD - a.profitRSD
+      case 'minimalni': return a.minimalniUlog - b.minimalniUlog
+      default: return a.naziv.localeCompare(b.naziv)
+    }
+  })
+  return rows
+})
+
+async function load() {
+  loading.value = true
+  errorMsg.value = ''
+  try {
+    const [allRes, mineRes] = await Promise.all([fundApi.list(), fundApi.mine()])
+    funds.value = allRes.data?.funds ?? []
+    myFunds.value = mineRes.data?.funds ?? []
+  } catch (err: any) {
+    errorMsg.value = err?.response?.data?.message ?? 'Greska pri ucitavanju fondova.'
+  } finally {
+    loading.value = false
+  }
+}
+
+function openFund(id: number) {
+  router.push(`/funds/${id}`)
+}
+
+function openCreate() {
+  router.push('/funds/new')
+}
+
+onMounted(load)
+</script>
+
+<template>
+  <div class="funds-view">
+    <header class="view-header">
+      <div>
+        <h1>Investicioni fondovi</h1>
+        <p>Pregled svih fondova i fondova kojima upravljate.</p>
+      </div>
+      <div class="header-actions">
+        <button v-if="isSupervisor" class="btn-primary" @click="openCreate">Kreiraj fond</button>
+      </div>
+    </header>
+
+    <div class="tabs">
+      <button :class="{ active: activeTab === 'all' }" @click="activeTab = 'all'">Svi fondovi ({{ funds.length }})</button>
+      <button v-if="isSupervisor" :class="{ active: activeTab === 'mine' }" @click="activeTab = 'mine'">Moji fondovi ({{ myFunds.length }})</button>
+    </div>
+
+    <div v-if="errorMsg" class="error-box">{{ errorMsg }}</div>
+
+    <section class="card">
+      <div class="filters">
+        <input type="text" v-model="search" placeholder="Pretraga..." />
+        <select v-model="sortKey">
+          <option value="naziv">Sortiraj: naziv</option>
+          <option value="value">Sortiraj: vrednost</option>
+          <option value="profit">Sortiraj: profit</option>
+          <option value="minimalni">Sortiraj: min. ulog</option>
+        </select>
+      </div>
+      <div v-if="loading" class="hint">Ucitavam...</div>
+      <table v-else-if="filtered.length > 0" class="data-table">
+        <thead>
+          <tr>
+            <th>Naziv</th>
+            <th>Opis</th>
+            <th class="num">Vrednost (RSD)</th>
+            <th class="num">Likvidnost (RSD)</th>
+            <th class="num">Profit (RSD)</th>
+            <th class="num">Ucesnici</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="f in filtered" :key="f.id" class="clickable" @click="openFund(f.id)">
+            <td><strong>{{ f.naziv }}</strong></td>
+            <td class="muted">{{ f.opis }}</td>
+            <td class="num">{{ f.fundValueRSD.toFixed(2) }}</td>
+            <td class="num">{{ f.liquidCashRSD.toFixed(2) }}</td>
+            <td class="num" :class="f.profitRSD >= 0 ? 'positive' : 'negative'">{{ f.profitRSD.toFixed(2) }}</td>
+            <td class="num">{{ f.participantsCount }}</td>
+            <td><button class="btn-secondary" @click.stop="openFund(f.id)">Otvori</button></td>
+          </tr>
+        </tbody>
+      </table>
+      <p v-else class="hint">Nema fondova za prikaz.</p>
+    </section>
+  </div>
+</template>
+
+<style scoped>
+.funds-view { padding: 32px; max-width: 1200px; margin: 0 auto; }
+.view-header { display: flex; justify-content: space-between; align-items: flex-start; margin-bottom: 16px; }
+.view-header h1 { margin: 0 0 4px; font-size: 28px; color: #0f172a; }
+.view-header p { margin: 0 0 8px; color: #64748b; }
+.tabs { display: flex; gap: 8px; margin-bottom: 16px; }
+.tabs button { padding: 10px 18px; border: 1px solid #cbd5e1; border-radius: 10px; background: #fff; cursor: pointer; font-weight: 600; color: #475569; }
+.tabs button.active { background: #0f172a; color: #fff; border-color: #0f172a; }
+.card { background: #fff; border-radius: 16px; padding: 20px; box-shadow: 0 2px 12px rgba(15,23,42,0.05); }
+.filters { display: flex; gap: 12px; margin-bottom: 16px; }
+.filters input, .filters select { padding: 9px 12px; border: 1px solid #cbd5e1; border-radius: 8px; font-size: 14px; }
+.filters input { flex: 1; }
+.data-table { width: 100%; border-collapse: collapse; }
+.data-table th, .data-table td { padding: 12px 8px; border-bottom: 1px solid #f1f5f9; text-align: left; font-size: 14px; }
+.data-table th { color: #64748b; font-weight: 600; font-size: 12px; text-transform: uppercase; letter-spacing: 0.04em; }
+.data-table .num { text-align: right; font-variant-numeric: tabular-nums; }
+.data-table tr.clickable { cursor: pointer; }
+.data-table tr.clickable:hover td { background: #f8fafc; }
+.muted { color: #64748b; }
+.positive { color: #16a34a; }
+.negative { color: #dc2626; }
+.btn-primary { padding: 8px 18px; border-radius: 10px; border: none; background: #2563eb; color: #fff; font-weight: 600; cursor: pointer; font-size: 14px; }
+.btn-secondary { padding: 6px 14px; border-radius: 8px; border: 1px solid #cbd5e1; background: #fff; color: #374151; font-weight: 600; cursor: pointer; font-size: 13px; }
+.error-box { background: #fef2f2; border: 1px solid #fca5a5; border-radius: 10px; padding: 10px 14px; color: #b91c1c; margin-bottom: 16px; }
+.hint { color: #64748b; padding: 20px 0; text-align: center; }
+</style>

--- a/src/views/EmployeeLayout.vue
+++ b/src/views/EmployeeLayout.vue
@@ -24,6 +24,7 @@ const allNavItems = [
   { to: '/actuaries', label: 'Aktuari', icon: 'A', perm: 'supervisor' },
   { to: '/orders', label: 'Nalozi', icon: 'N', perm: 'supervisor' },
   { to: '/tax', label: 'Porez', icon: 'T', perm: 'supervisor' },
+  { to: '/funds', label: 'Fondovi', icon: 'F', perm: 'stockTrading' },
   { to: '/loans/requests', label: 'Zahtevi kredita', icon: 'Z', perm: 'bankOps' },
   { to: '/loans', label: 'Krediti', icon: 'K', perm: 'bankOps' },
 ]

--- a/src/views/client/ClientFundDetailView.vue
+++ b/src/views/client/ClientFundDetailView.vue
@@ -1,0 +1,327 @@
+<script setup lang="ts">
+import { computed, onMounted, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { Line } from 'vue-chartjs'
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Title,
+  Tooltip,
+  Filler,
+  type ChartData,
+  type ChartOptions,
+} from 'chart.js'
+import {
+  clientFundApi,
+  type FundSummary,
+  type FundHolding,
+  type FundPerformancePoint,
+} from '../../api/fund'
+import { clientAccountApi } from '../../api/clientAccount'
+import { useClientAuthStore } from '../../stores/clientAuth'
+
+ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Title, Tooltip, Filler)
+
+const route = useRoute()
+const router = useRouter()
+const clientAuth = useClientAuthStore()
+const fundId = computed(() => Number(route.params.id))
+
+const fund = ref<FundSummary | null>(null)
+const holdings = ref<FundHolding[]>([])
+const performance = ref<FundPerformancePoint[]>([])
+const granularity = ref<'monthly' | 'quarterly' | 'yearly'>('monthly')
+
+const loading = ref(false)
+const errorMsg = ref('')
+
+const accounts = ref<Array<{ id: number; label: string; balance: number; currency: string }>>([])
+const investOpen = ref(false)
+const withdrawOpen = ref(false)
+const investAmount = ref(0)
+const investAccountId = ref<number | null>(null)
+const withdrawAmount = ref(0)
+const withdrawAll = ref(false)
+const withdrawAccountId = ref<number | null>(null)
+const dialogBusy = ref(false)
+const dialogError = ref('')
+
+async function load() {
+  loading.value = true
+  errorMsg.value = ''
+  try {
+    const [fundRes, holdingsRes, perfRes] = await Promise.all([
+      clientFundApi.get(fundId.value),
+      clientFundApi.holdings(fundId.value),
+      clientFundApi.performance(fundId.value, granularity.value),
+    ])
+    fund.value = fundRes.data?.fund ?? null
+    holdings.value = holdingsRes.data?.holdings ?? []
+    performance.value = perfRes.data?.performance ?? []
+  } catch (err: any) {
+    errorMsg.value = err?.response?.data?.message ?? 'Greska pri ucitavanju fonda.'
+  } finally {
+    loading.value = false
+  }
+}
+
+async function loadAccounts() {
+  const clientId = clientAuth.client?.id
+  if (!clientId) return
+  try {
+    const res = await clientAccountApi.listByClient(clientId)
+    const items: any[] = res.data?.accounts ?? res.data ?? []
+    accounts.value = items
+      .filter((a: any) => a.status === 'aktivan' && (a.currencyKod === 'RSD' || a.currency?.kod === 'RSD'))
+      .map((a: any) => ({
+        id: Number(a.id),
+        label: `${a.naziv || a.brojRacuna}`,
+        balance: Number(a.raspolozivoStanje),
+        currency: a.currencyKod || a.currency?.kod || 'RSD',
+      }))
+    if (accounts.value.length > 0) {
+      if (investAccountId.value === null) investAccountId.value = accounts.value[0]!.id
+      if (withdrawAccountId.value === null) withdrawAccountId.value = accounts.value[0]!.id
+    }
+  } catch {
+    // ignore
+  }
+}
+
+watch(granularity, async () => {
+  try {
+    const res = await clientFundApi.performance(fundId.value, granularity.value)
+    performance.value = res.data?.performance ?? []
+  } catch {
+    // ignore
+  }
+})
+
+async function submitInvest() {
+  if (!investAccountId.value || investAmount.value <= 0) return
+  dialogBusy.value = true
+  dialogError.value = ''
+  try {
+    await clientFundApi.invest(fundId.value, {
+      sourceAccountId: investAccountId.value,
+      amount: investAmount.value,
+    })
+    investOpen.value = false
+    investAmount.value = 0
+    await load()
+  } catch (err: any) {
+    dialogError.value = err?.response?.data?.message ?? 'Greska pri uplati.'
+  } finally {
+    dialogBusy.value = false
+  }
+}
+
+async function submitWithdraw() {
+  if (!withdrawAccountId.value) return
+  dialogBusy.value = true
+  dialogError.value = ''
+  try {
+    const res = await clientFundApi.withdraw(fundId.value, {
+      destinationAccountId: withdrawAccountId.value,
+      amount: withdrawAll.value ? undefined : withdrawAmount.value,
+      withdrawAll: withdrawAll.value,
+    })
+    withdrawOpen.value = false
+    withdrawAmount.value = 0
+    withdrawAll.value = false
+    const data = res.data
+    if (data?.liquidated) {
+      alert(`Povucenа suma ${data.grossWithdrawn.toFixed(2)} RSD (od cega ${data.commission.toFixed(2)} RSD provizija). Auto-likvidirano je ${data.liquidatedItems.length} pozicija u fondu.`)
+    }
+    await load()
+  } catch (err: any) {
+    dialogError.value = err?.response?.data?.message ?? 'Greska pri povlacenju.'
+  } finally {
+    dialogBusy.value = false
+  }
+}
+
+const chartData = computed<ChartData<'line'>>(() => ({
+  labels: performance.value.map((p) => p.date),
+  datasets: [
+    {
+      label: 'Vrednost fonda (RSD)',
+      data: performance.value.map((p) => p.fundValue),
+      borderColor: '#2563eb',
+      backgroundColor: 'rgba(37,99,235,0.08)',
+      borderWidth: 2,
+      pointRadius: 3,
+      fill: true,
+      tension: 0.3,
+    },
+  ],
+}))
+const chartOptions: ChartOptions<'line'> = {
+  responsive: true,
+  maintainAspectRatio: false,
+  plugins: { legend: { display: false }, tooltip: { enabled: true } },
+  scales: {
+    x: { grid: { display: false } },
+    y: { ticks: { callback: (v: any) => `${Number(v).toLocaleString()}` } },
+  },
+}
+
+onMounted(async () => {
+  await load()
+  await loadAccounts()
+})
+</script>
+
+<template>
+  <div class="fund-detail">
+    <button class="back-btn" @click="router.push('/client/funds')">&larr; Nazad na listu</button>
+
+    <div v-if="errorMsg" class="error-box">{{ errorMsg }}</div>
+    <div v-if="loading" class="hint">Ucitavam...</div>
+
+    <template v-else-if="fund">
+      <header class="card">
+        <h1>{{ fund.naziv }}</h1>
+        <p class="muted">{{ fund.opis }}</p>
+        <div class="kpi-grid">
+          <div class="kpi"><span>Vrednost fonda</span><strong>{{ fund.fundValueRSD.toFixed(2) }} RSD</strong></div>
+          <div class="kpi"><span>Likvidnost</span><strong>{{ fund.liquidCashRSD.toFixed(2) }} RSD</strong></div>
+          <div class="kpi"><span>Profit</span><strong :class="fund.profitRSD >= 0 ? 'positive' : 'negative'">{{ fund.profitRSD.toFixed(2) }} RSD</strong></div>
+          <div class="kpi"><span>Minimalni ulog</span><strong>{{ fund.minimalniUlog.toFixed(2) }} RSD</strong></div>
+          <div class="kpi"><span>Ucesnika</span><strong>{{ fund.participantsCount }}</strong></div>
+        </div>
+        <div class="actions">
+          <button class="btn-primary" @click="investOpen = true">Uplati u fond</button>
+          <button class="btn-secondary" @click="withdrawOpen = true">Povuci sredstva</button>
+        </div>
+      </header>
+
+      <section class="card">
+        <div class="section-header">
+          <h2>Performanse fonda</h2>
+          <select v-model="granularity">
+            <option value="monthly">Mesecno</option>
+            <option value="quarterly">Kvartalno</option>
+            <option value="yearly">Godisnje</option>
+          </select>
+        </div>
+        <div class="chart-wrapper">
+          <Line v-if="performance.length > 0" :data="chartData" :options="chartOptions" />
+          <p v-else class="hint">Nema istorijskih podataka.</p>
+        </div>
+      </section>
+
+      <section class="card">
+        <h2>Hartije u fondu</h2>
+        <table v-if="holdings.length > 0" class="data-table">
+          <thead>
+            <tr>
+              <th>Ticker</th><th>Naziv</th>
+              <th class="num">Cena</th><th class="num">Promena</th><th class="num">Volume</th>
+              <th class="num">Kolicina</th><th class="num">Pros. cena kupovine</th>
+              <th>Datum sticanja</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="h in holdings" :key="h.id">
+              <td><strong>{{ h.ticker }}</strong></td>
+              <td>{{ h.name }}</td>
+              <td class="num">{{ h.price.toFixed(2) }}</td>
+              <td class="num">{{ h.change.toFixed(2) }}</td>
+              <td class="num">{{ h.volume.toLocaleString() }}</td>
+              <td class="num">{{ h.quantity.toFixed(2) }}</td>
+              <td class="num">{{ h.avgBuyPrice.toFixed(2) }}</td>
+              <td>{{ h.acquisitionDate }}</td>
+            </tr>
+          </tbody>
+        </table>
+        <p v-else class="hint">Fond jos uvek nema hartija.</p>
+      </section>
+    </template>
+
+    <!-- Invest modal -->
+    <div v-if="investOpen" class="modal-overlay" @click.self="investOpen = false">
+      <div class="modal-box">
+        <h2>Uplata u fond</h2>
+        <div v-if="dialogError" class="error-box">{{ dialogError }}</div>
+        <div class="field">
+          <label>Izvorni racun (RSD)</label>
+          <select v-model.number="investAccountId">
+            <option v-for="a in accounts" :key="a.id" :value="a.id">{{ a.label }} ({{ a.balance.toFixed(2) }} RSD)</option>
+          </select>
+        </div>
+        <div class="field">
+          <label>Iznos (min. {{ fund?.minimalniUlog.toFixed(2) }} RSD)</label>
+          <input type="number" v-model.number="investAmount" min="0" step="0.01" />
+        </div>
+        <div class="modal-actions">
+          <button class="btn-secondary" :disabled="dialogBusy" @click="investOpen = false">Otkazi</button>
+          <button class="btn-primary" :disabled="dialogBusy" @click="submitInvest">{{ dialogBusy ? 'Slanje...' : 'Uplati' }}</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Withdraw modal -->
+    <div v-if="withdrawOpen" class="modal-overlay" @click.self="withdrawOpen = false">
+      <div class="modal-box">
+        <h2>Povlacenje sredstava</h2>
+        <div v-if="dialogError" class="error-box">{{ dialogError }}</div>
+        <div class="field">
+          <label>Destinacioni racun</label>
+          <select v-model.number="withdrawAccountId">
+            <option v-for="a in accounts" :key="a.id" :value="a.id">{{ a.label }}</option>
+          </select>
+        </div>
+        <div class="field">
+          <label class="check"><input type="checkbox" v-model="withdrawAll" /> Povuci celu poziciju</label>
+        </div>
+        <div v-if="!withdrawAll" class="field">
+          <label>Iznos (RSD)</label>
+          <input type="number" v-model.number="withdrawAmount" min="0" step="0.01" />
+        </div>
+        <p class="hint">Provizija {{ ((fund?.withdrawalCommRate ?? 0) * 100).toFixed(2) }} % bice odbijena pri isplati.</p>
+        <div class="modal-actions">
+          <button class="btn-secondary" :disabled="dialogBusy" @click="withdrawOpen = false">Otkazi</button>
+          <button class="btn-primary" :disabled="dialogBusy" @click="submitWithdraw">{{ dialogBusy ? 'Slanje...' : 'Povuci' }}</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.fund-detail { padding: 32px; max-width: 1200px; margin: 0 auto; }
+.back-btn { background: none; border: none; color: #2563eb; font-size: 14px; cursor: pointer; margin-bottom: 16px; }
+.card { background: #fff; border-radius: 16px; padding: 24px; box-shadow: 0 2px 12px rgba(15,23,42,0.05); margin-bottom: 24px; }
+.card h1 { margin: 0 0 6px; color: #0f172a; font-size: 26px; }
+.card h2 { margin: 0 0 16px; color: #0f172a; font-size: 18px; }
+.muted { color: #64748b; margin: 0 0 20px; }
+.kpi-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 14px; margin-bottom: 20px; }
+.kpi { background: #f8fafc; padding: 14px; border-radius: 12px; }
+.kpi span { display: block; color: #64748b; font-size: 12px; text-transform: uppercase; letter-spacing: 0.04em; margin-bottom: 4px; }
+.kpi strong { font-size: 20px; color: #0f172a; }
+.actions { display: flex; gap: 10px; }
+.section-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 16px; }
+.section-header select { padding: 7px 12px; border: 1px solid #cbd5e1; border-radius: 8px; font-size: 13px; }
+.chart-wrapper { position: relative; height: 320px; }
+.data-table { width: 100%; border-collapse: collapse; }
+.data-table th, .data-table td { padding: 10px 8px; border-bottom: 1px solid #f1f5f9; text-align: left; font-size: 14px; }
+.data-table th { color: #64748b; font-size: 12px; text-transform: uppercase; letter-spacing: 0.04em; }
+.data-table .num { text-align: right; font-variant-numeric: tabular-nums; }
+.positive { color: #16a34a; }
+.negative { color: #dc2626; }
+.btn-primary { padding: 9px 18px; border: none; border-radius: 10px; background: #2563eb; color: #fff; font-weight: 600; cursor: pointer; }
+.btn-secondary { padding: 9px 18px; border: 1px solid #cbd5e1; border-radius: 10px; background: #fff; color: #374151; font-weight: 600; cursor: pointer; }
+.error-box { background: #fef2f2; border: 1px solid #fca5a5; border-radius: 10px; padding: 10px 14px; color: #b91c1c; margin-bottom: 14px; }
+.hint { color: #64748b; text-align: center; padding: 20px 0; }
+.modal-overlay { position: fixed; inset: 0; background: rgba(15,23,42,0.45); display: flex; align-items: center; justify-content: center; z-index: 1000; padding: 16px; }
+.modal-box { background: #fff; border-radius: 18px; padding: 24px; width: 100%; max-width: 480px; }
+.field { display: flex; flex-direction: column; gap: 5px; margin-bottom: 14px; }
+.field label { font-size: 12px; font-weight: 600; color: #475569; text-transform: uppercase; letter-spacing: 0.04em; }
+.field label.check { text-transform: none; font-weight: 500; color: #0f172a; font-size: 14px; display: flex; align-items: center; gap: 8px; }
+.field input, .field select { padding: 9px 12px; border: 1px solid #cbd5e1; border-radius: 8px; font-size: 14px; }
+.modal-actions { display: flex; gap: 10px; justify-content: flex-end; margin-top: 12px; }
+</style>

--- a/src/views/client/ClientFundsView.vue
+++ b/src/views/client/ClientFundsView.vue
@@ -1,0 +1,161 @@
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { clientFundApi, type FundSummary, type FundPositionView } from '../../api/fund'
+
+const router = useRouter()
+const activeTab = ref<'all' | 'mine'>('all')
+const funds = ref<FundSummary[]>([])
+const myPositions = ref<FundPositionView[]>([])
+const loading = ref(false)
+const errorMsg = ref('')
+
+const sortKey = ref<'naziv' | 'value' | 'profit' | 'minimalni'>('naziv')
+const search = ref('')
+
+const filtered = computed(() => {
+  let rows = [...funds.value]
+  if (search.value.trim()) {
+    const q = search.value.toLowerCase()
+    rows = rows.filter((f) => f.naziv.toLowerCase().includes(q) || f.opis.toLowerCase().includes(q))
+  }
+  rows.sort((a, b) => {
+    switch (sortKey.value) {
+      case 'value': return b.fundValueRSD - a.fundValueRSD
+      case 'profit': return b.profitRSD - a.profitRSD
+      case 'minimalni': return a.minimalniUlog - b.minimalniUlog
+      default: return a.naziv.localeCompare(b.naziv)
+    }
+  })
+  return rows
+})
+
+async function load() {
+  loading.value = true
+  errorMsg.value = ''
+  try {
+    const [allRes, mineRes] = await Promise.all([clientFundApi.list(), clientFundApi.mine()])
+    funds.value = allRes.data?.funds ?? []
+    myPositions.value = mineRes.data?.positions ?? []
+  } catch (err: any) {
+    errorMsg.value = err?.response?.data?.message ?? 'Greska pri ucitavanju fondova.'
+  } finally {
+    loading.value = false
+  }
+}
+
+function openFund(id: number) {
+  router.push(`/client/funds/${id}`)
+}
+
+onMounted(load)
+</script>
+
+<template>
+  <div class="funds-view">
+    <header class="view-header">
+      <h1>Investicioni fondovi</h1>
+      <p>Pregled svih dostupnih fondova i vasih ulaganja.</p>
+    </header>
+
+    <div class="tabs">
+      <button :class="{ active: activeTab === 'all' }" @click="activeTab = 'all'">Svi fondovi</button>
+      <button :class="{ active: activeTab === 'mine' }" @click="activeTab = 'mine'">Moji fondovi ({{ myPositions.length }})</button>
+    </div>
+
+    <div v-if="errorMsg" class="error-box">{{ errorMsg }}</div>
+
+    <!-- All funds tab -->
+    <section v-if="activeTab === 'all'" class="card">
+      <div class="filters">
+        <input type="text" v-model="search" placeholder="Pretraga po nazivu ili opisu..." />
+        <select v-model="sortKey">
+          <option value="naziv">Sortiraj: naziv</option>
+          <option value="value">Sortiraj: vrednost</option>
+          <option value="profit">Sortiraj: profit</option>
+          <option value="minimalni">Sortiraj: minimalni ulog</option>
+        </select>
+      </div>
+      <div v-if="loading" class="hint">Ucitavam...</div>
+      <table v-else-if="filtered.length > 0" class="data-table">
+        <thead>
+          <tr>
+            <th>Naziv</th>
+            <th>Opis</th>
+            <th class="num">Vrednost (RSD)</th>
+            <th class="num">Profit (RSD)</th>
+            <th class="num">Min. ulog</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="f in filtered" :key="f.id" class="clickable" @click="openFund(f.id)">
+            <td><strong>{{ f.naziv }}</strong></td>
+            <td class="muted">{{ f.opis }}</td>
+            <td class="num">{{ f.fundValueRSD.toFixed(2) }}</td>
+            <td class="num" :class="f.profitRSD >= 0 ? 'positive' : 'negative'">{{ f.profitRSD.toFixed(2) }}</td>
+            <td class="num">{{ f.minimalniUlog.toFixed(2) }}</td>
+            <td><button class="btn-primary" @click.stop="openFund(f.id)">Investiraj</button></td>
+          </tr>
+        </tbody>
+      </table>
+      <p v-else class="hint">Nema dostupnih fondova.</p>
+    </section>
+
+    <!-- My positions tab -->
+    <section v-else class="card">
+      <div v-if="loading" class="hint">Ucitavam...</div>
+      <table v-else-if="myPositions.length > 0" class="data-table">
+        <thead>
+          <tr>
+            <th>Fond</th>
+            <th class="num">Vrednost fonda (RSD)</th>
+            <th class="num">Ulozeno (RSD)</th>
+            <th class="num">Udeo (%)</th>
+            <th class="num">Trenutna vrednost</th>
+            <th class="num">Profit</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="p in myPositions" :key="p.fundId" class="clickable" @click="openFund(p.fundId)">
+            <td><strong>{{ p.naziv }}</strong></td>
+            <td class="num">{{ p.fundValueRSD.toFixed(2) }}</td>
+            <td class="num">{{ p.ukupanUlozeniRSD.toFixed(2) }}</td>
+            <td class="num">{{ p.udeoProcenat.toFixed(2) }} %</td>
+            <td class="num">{{ p.trenutnaVrednost.toFixed(2) }}</td>
+            <td class="num" :class="p.profitRSD >= 0 ? 'positive' : 'negative'">{{ p.profitRSD.toFixed(2) }}</td>
+            <td><button class="btn-primary" @click.stop="openFund(p.fundId)">Otvori</button></td>
+          </tr>
+        </tbody>
+      </table>
+      <p v-else class="hint">Jos uvek niste ulozili ni u jedan fond.</p>
+    </section>
+  </div>
+</template>
+
+<style scoped>
+.funds-view { padding: 32px; max-width: 1200px; margin: 0 auto; }
+.view-header h1 { margin: 0 0 4px; font-size: 28px; color: #0f172a; }
+.view-header p { margin: 0 0 24px; color: #64748b; }
+.tabs { display: flex; gap: 8px; margin-bottom: 16px; }
+.tabs button { padding: 10px 18px; border: 1px solid #cbd5e1; border-radius: 10px; background: #fff; cursor: pointer; font-weight: 600; color: #475569; }
+.tabs button.active { background: #0f172a; color: #fff; border-color: #0f172a; }
+.card { background: #fff; border-radius: 16px; padding: 20px; box-shadow: 0 2px 12px rgba(15,23,42,0.05); }
+.filters { display: flex; gap: 12px; margin-bottom: 16px; }
+.filters input, .filters select { padding: 9px 12px; border: 1px solid #cbd5e1; border-radius: 8px; font-size: 14px; }
+.filters input { flex: 1; }
+.data-table { width: 100%; border-collapse: collapse; }
+.data-table th, .data-table td { padding: 12px 8px; border-bottom: 1px solid #f1f5f9; text-align: left; font-size: 14px; }
+.data-table th { color: #64748b; font-weight: 600; font-size: 12px; text-transform: uppercase; letter-spacing: 0.04em; }
+.data-table .num { text-align: right; font-variant-numeric: tabular-nums; }
+.data-table tr.clickable { cursor: pointer; }
+.data-table tr.clickable:hover td { background: #f8fafc; }
+.muted { color: #64748b; }
+.positive { color: #16a34a; }
+.negative { color: #dc2626; }
+.btn-primary { padding: 6px 14px; border-radius: 8px; border: none; background: #2563eb; color: #fff; font-weight: 600; cursor: pointer; font-size: 13px; }
+.btn-primary:hover { background: #1d4ed8; }
+.error-box { background: #fef2f2; border: 1px solid #fca5a5; border-radius: 10px; padding: 10px 14px; color: #b91c1c; margin-bottom: 16px; }
+.hint { color: #64748b; padding: 20px 0; text-align: center; }
+</style>

--- a/src/views/client/ClientLayout.vue
+++ b/src/views/client/ClientLayout.vue
@@ -58,6 +58,10 @@ function isPaymentSection() {
           OTC ponude
         </RouterLink>
 
+        <RouterLink to="/client/funds" class="sidebar-link" :class="{ active: isActive('/client/funds') }">
+          <span class="sidebar-icon">F</span><span>Fondovi</span>
+        </RouterLink>
+
         <RouterLink to="/client/transfers" class="sidebar-link" :class="{ active: isActive('/client/transfers') }">
           <span class="sidebar-icon">&lt;&gt;</span><span>Transferi</span>
         </RouterLink>


### PR DESCRIPTION
- New /api/fund.ts shared between client and employee auth contexts
- Client portal: Funds discovery + detail (Chart.js performance) with invest / withdraw modals, sidebar entry
- Employee portal: Funds discovery (all + my funds tab), detail with bank-invest dialog and supervisor-only create-fund form, sidebar entry
- BuyOrderModal: "Za banku / Za fond" radio + fund picker for supervisors, forwards fundId to the order create endpoint
- nginx: proxy /api/v1/funds to exchange-service
- Router: client + employee fund routes; create-fund gated by employeeSupervisor