### PR TITLE
feat(interbank): sprint 9 cross-bank payment + OTC portal frontend

### DIFF
--- a/src/api/interbankOtc.ts
+++ b/src/api/interbankOtc.ts
@@ -1,0 +1,165 @@
+import clientApi from './clientAuth'
+
+// ─── Public-stocks (cross-bank catalogue) ──────────────────────────────
+
+export interface InterbankPublicStockSeller {
+  bankRoutingNumber: number
+  bankDisplayName: string
+  sellerId: string
+  amount: number
+}
+
+export interface InterbankPublicStock {
+  ticker: string
+  sellers: InterbankPublicStockSeller[]
+}
+
+export interface InterbankPublicStocksResponse {
+  stocks: InterbankPublicStock[]
+  count: number
+  partnerErrors: Record<string, string>
+  partnerStale: Record<string, boolean>
+  source: 'cache' | 'live'
+}
+
+// ─── Negotiations ──────────────────────────────────────────────────────
+
+export type InterbankNegotiationRole = 'buyer' | 'seller'
+
+export interface InterbankBankId {
+  routingNumber: number
+  id: string
+}
+
+export interface InterbankNegotiation {
+  negotiationRoutingNumber: number
+  negotiationId: string
+  localRole: InterbankNegotiationRole
+  counterpartyRoutingNumber: number
+  buyerId: InterbankBankId
+  sellerId: InterbankBankId
+  stock: { ticker: string }
+  amount: number
+  pricePerUnit: { currency: string; amount: number }
+  premium: { currency: string; amount: number }
+  settlementDate: string
+  lastModifiedBy: InterbankBankId
+  isOngoing: boolean
+  createdAt: string
+  updatedAt: string
+}
+
+export interface CreateInterbankNegotiationPayload {
+  sellerId: InterbankBankId
+  stock: { ticker: string }
+  settlementDate: string
+  pricePerUnit: { currency: string; amount: number }
+  premium: { currency: string; amount: number }
+  amount: number
+}
+
+export interface CounterInterbankNegotiationPayload {
+  stock: { ticker: string }
+  settlementDate: string
+  pricePerUnit: { currency: string; amount: number }
+  premium: { currency: string; amount: number }
+  amount: number
+}
+
+// ─── Option contracts (buyer-side cross-bank options) ──────────────────
+
+export type InterbankOptionContractStatus = 'valid' | 'exercised' | 'expired'
+
+export interface InterbankOptionContract {
+  id: number
+  negotiationRoutingNumber: number
+  negotiationId: string
+  buyerLocalId: string
+  sellerRoutingNumber: number
+  sellerId: string
+  stockTicker: string
+  amount: number
+  pricePerUnit: { currency: string; amount: number }
+  premium: { currency: string; amount: number }
+  settlementDate: string
+  status: InterbankOptionContractStatus
+  createdAt: string
+  updatedAt: string
+}
+
+export interface ExerciseOptionContractResponse {
+  exerciseId?: number
+  status: 'committed' | 'rejected' | 'failed' | 'pending' | 'rolled_back'
+  contract?: InterbankOptionContract
+  message?: string
+  vote?: unknown
+}
+
+// ─── API ───────────────────────────────────────────────────────────────
+
+export const interbankOtcApi = {
+  // public-stocks
+  listPublicStocks: (live = false) =>
+    clientApi.get<InterbankPublicStocksResponse>('/interbank-otc/public-stocks', {
+      params: live ? { live: 'true' } : {},
+    }),
+
+  // negotiations
+  listNegotiations: (role: '' | InterbankNegotiationRole = '', includeClosed = false) =>
+    clientApi.get<{ negotiations: InterbankNegotiation[]; count: number }>(
+      '/interbank-otc/negotiations',
+      {
+        params: {
+          role: role || undefined,
+          includeClosed: includeClosed ? 'true' : undefined,
+        },
+      },
+    ),
+
+  createNegotiation: (payload: CreateInterbankNegotiationPayload) =>
+    clientApi.post<{ negotiation: InterbankNegotiation }>(
+      '/interbank-otc/negotiations',
+      payload,
+    ),
+
+  getNegotiation: (routingNumber: number, id: string) =>
+    clientApi.get<{ negotiation: InterbankNegotiation }>(
+      `/interbank-otc/negotiations/${routingNumber}/${encodeURIComponent(id)}`,
+    ),
+
+  counterNegotiation: (
+    routingNumber: number,
+    id: string,
+    payload: CounterInterbankNegotiationPayload,
+  ) =>
+    clientApi.put<{ negotiation: InterbankNegotiation }>(
+      `/interbank-otc/negotiations/${routingNumber}/${encodeURIComponent(id)}`,
+      payload,
+    ),
+
+  acceptNegotiation: (routingNumber: number, id: string) =>
+    clientApi.post<{ negotiation: InterbankNegotiation; contract?: InterbankOptionContract }>(
+      `/interbank-otc/negotiations/${routingNumber}/${encodeURIComponent(id)}/accept`,
+    ),
+
+  closeNegotiation: (routingNumber: number, id: string) =>
+    clientApi.delete<{ negotiation: InterbankNegotiation }>(
+      `/interbank-otc/negotiations/${routingNumber}/${encodeURIComponent(id)}`,
+    ),
+
+  // option contracts
+  listOptionContracts: () =>
+    clientApi.get<{ contracts: InterbankOptionContract[]; count: number }>(
+      '/interbank-otc/option-contracts',
+    ),
+
+  getOptionContract: (id: number) =>
+    clientApi.get<{ contract: InterbankOptionContract }>(
+      `/interbank-otc/option-contracts/${id}`,
+    ),
+
+  exerciseOptionContract: (id: number) =>
+    clientApi.post<ExerciseOptionContractResponse>(
+      `/interbank-otc/option-contracts/${id}/exercise`,
+    ),
+}

--- a/src/api/payment.ts
+++ b/src/api/payment.ts
@@ -91,3 +91,43 @@ export const paymentApi = {
   get: (id: string) =>
     clientApi.get(`/payments/${id}`),
 }
+
+export interface CrossBankPaymentResponse {
+  id: number
+  transactionId: { routingNumber: number; id: string }
+  direction: string
+  partnerRoutingNumber: number
+  senderAccountNumber: string
+  recipientAccountNumber: string
+  currency: string
+  amount: number
+  message?: string
+  paymentCode?: string
+  paymentPurpose?: string
+  status: 'pending' | 'committed' | 'rejected' | 'failed' | 'rolled_back'
+  lastError?: string
+  createdAt: string
+  updatedAt: string
+  resolvedAt?: string
+}
+
+export interface CreateCrossBankPayload {
+  senderAccountNumber: string
+  recipientAccountNumber: string
+  currency: string
+  amount: number
+  message?: string
+  paymentCode?: string
+  paymentPurpose?: string
+}
+
+export const crossBankPaymentApi = {
+  create: (data: CreateCrossBankPayload) =>
+    clientApi.post('/payments/cross-bank', data),
+
+  list: (limit = 50) =>
+    clientApi.get('/payments/cross-bank', { params: { limit } }),
+
+  get: (id: number | string) =>
+    clientApi.get(`/payments/cross-bank/${id}`),
+}

--- a/src/router/clientRoutes.ts
+++ b/src/router/clientRoutes.ts
@@ -51,6 +51,11 @@ export const clientRoutes: RouteRecordRaw[] = [
         meta: { clientTradingOnly: true },
       },
       {
+        path: 'otc/interbank',
+        component: () => import('../views/client/ClientInterbankOtcView.vue'),
+        meta: { clientTradingOnly: true },
+      },
+      {
         path: 'funds',
         component: () => import('../views/client/ClientFundsView.vue'),
       },

--- a/src/utils/accountValidation.ts
+++ b/src/utils/accountValidation.ts
@@ -1,3 +1,12 @@
+export const OWN_BANK_CODE = '111'
+
+export const PARTNER_BANK_NAMES: Record<string, string> = {
+  '111': 'EXBanka-3',
+  '222': 'Banka 2',
+  '333': 'Banka 3',
+  '444': 'Banka 4',
+}
+
 export function validateAccountNumber(broj: string): boolean {
   if (!/^\d{18}$/.test(broj)) return false
 
@@ -8,4 +17,17 @@ export function validateAccountNumber(broj: string): boolean {
   // Checksum: (sum of all digits) % 11 == 0
   const sum = broj.split('').reduce((s, ch) => s + Number(ch), 0)
   return sum % 11 === 0
+}
+
+export function bankCodeOf(broj: string): string {
+  return broj.slice(0, 3)
+}
+
+export function isCrossBankAccount(broj: string): boolean {
+  if (!/^\d{3}/.test(broj)) return false
+  return bankCodeOf(broj) !== OWN_BANK_CODE
+}
+
+export function bankNameOf(broj: string): string {
+  return PARTNER_BANK_NAMES[bankCodeOf(broj)] ?? `Banka ${bankCodeOf(broj)}`
 }

--- a/src/views/client/ClientInterbankOtcView.vue
+++ b/src/views/client/ClientInterbankOtcView.vue
@@ -1,0 +1,706 @@
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+import {
+  interbankOtcApi,
+  type InterbankPublicStock,
+  type InterbankPublicStockSeller,
+  type InterbankNegotiation,
+  type InterbankOptionContract,
+  type CreateInterbankNegotiationPayload,
+  type CounterInterbankNegotiationPayload,
+} from '../../api/interbankOtc'
+
+type TabKey = 'stocks' | 'negotiations' | 'contracts'
+
+const activeTab = ref<TabKey>('stocks')
+
+// ─── Public stocks ─────────────────────────────────────────────────────
+const stocks = ref<InterbankPublicStock[]>([])
+const stocksSource = ref<'cache' | 'live'>('cache')
+const stocksLoading = ref(false)
+const stocksError = ref('')
+const partnerErrors = ref<Record<string, string>>({})
+const partnerStale = ref<Record<string, boolean>>({})
+
+async function loadStocks(live = false) {
+  stocksLoading.value = true
+  stocksError.value = ''
+  try {
+    const res = await interbankOtcApi.listPublicStocks(live)
+    stocks.value = res.data.stocks ?? []
+    stocksSource.value = res.data.source
+    partnerErrors.value = res.data.partnerErrors ?? {}
+    partnerStale.value = res.data.partnerStale ?? {}
+  } catch (e: any) {
+    stocksError.value = e?.response?.data?.message || 'Greška pri učitavanju javnih akcija.'
+  } finally {
+    stocksLoading.value = false
+  }
+}
+
+// ─── Negotiations ──────────────────────────────────────────────────────
+const negotiations = ref<InterbankNegotiation[]>([])
+const negotiationsLoading = ref(false)
+const negotiationsError = ref('')
+const negotiationsFilter = ref<'' | 'buyer' | 'seller'>('')
+const includeClosed = ref(false)
+
+async function loadNegotiations() {
+  negotiationsLoading.value = true
+  negotiationsError.value = ''
+  try {
+    const res = await interbankOtcApi.listNegotiations(negotiationsFilter.value, includeClosed.value)
+    negotiations.value = res.data.negotiations ?? []
+  } catch (e: any) {
+    negotiationsError.value = e?.response?.data?.message || 'Greška pri učitavanju pregovora.'
+  } finally {
+    negotiationsLoading.value = false
+  }
+}
+
+// new negotiation form
+const showOfferForm = ref(false)
+const offerSeller = ref<InterbankPublicStockSeller | null>(null)
+const offerTicker = ref('')
+const offerForm = ref({
+  amount: '',
+  pricePerUnitAmount: '',
+  pricePerUnitCurrency: 'USD',
+  premiumAmount: '',
+  premiumCurrency: 'USD',
+  settlementDate: '',
+})
+const offerError = ref('')
+const offerSubmitting = ref(false)
+
+function openOfferForm(stock: InterbankPublicStock, seller: InterbankPublicStockSeller) {
+  offerSeller.value = seller
+  offerTicker.value = stock.ticker
+  const defaultSettlement = new Date()
+  defaultSettlement.setDate(defaultSettlement.getDate() + 30)
+  offerForm.value = {
+    amount: '',
+    pricePerUnitAmount: '',
+    pricePerUnitCurrency: 'USD',
+    premiumAmount: '',
+    premiumCurrency: 'USD',
+    settlementDate: defaultSettlement.toISOString().slice(0, 10),
+  }
+  offerError.value = ''
+  showOfferForm.value = true
+}
+
+function closeOfferForm() {
+  showOfferForm.value = false
+  offerSeller.value = null
+}
+
+async function submitOffer() {
+  if (!offerSeller.value) return
+  const amount = Number(offerForm.value.amount)
+  const price = Number(offerForm.value.pricePerUnitAmount)
+  const premium = Number(offerForm.value.premiumAmount)
+  if (!Number.isFinite(amount) || amount <= 0) { offerError.value = 'Količina mora biti pozitivna.'; return }
+  if (amount > offerSeller.value.amount) { offerError.value = 'Količina prelazi dostupnu kod prodavca.'; return }
+  if (!Number.isFinite(price) || price <= 0) { offerError.value = 'Cena po akciji mora biti pozitivna.'; return }
+  if (!Number.isFinite(premium) || premium < 0) { offerError.value = 'Premija ne može biti negativna.'; return }
+  if (!offerForm.value.settlementDate) { offerError.value = 'Settlement date je obavezan.'; return }
+
+  const payload: CreateInterbankNegotiationPayload = {
+    sellerId: {
+      routingNumber: offerSeller.value.bankRoutingNumber,
+      id: offerSeller.value.sellerId,
+    },
+    stock: { ticker: offerTicker.value },
+    settlementDate: offerForm.value.settlementDate,
+    pricePerUnit: { currency: offerForm.value.pricePerUnitCurrency, amount: price },
+    premium: { currency: offerForm.value.premiumCurrency, amount: premium },
+    amount,
+  }
+  offerSubmitting.value = true
+  offerError.value = ''
+  try {
+    await interbankOtcApi.createNegotiation(payload)
+    closeOfferForm()
+    activeTab.value = 'negotiations'
+    await loadNegotiations()
+  } catch (e: any) {
+    offerError.value = e?.response?.data?.message || 'Greška pri slanju ponude.'
+  } finally {
+    offerSubmitting.value = false
+  }
+}
+
+// counter / accept / close actions
+const counterTarget = ref<InterbankNegotiation | null>(null)
+const counterForm = ref({
+  amount: '',
+  pricePerUnitAmount: '',
+  premiumAmount: '',
+  settlementDate: '',
+})
+const counterError = ref('')
+const counterSubmitting = ref(false)
+
+function openCounterForm(neg: InterbankNegotiation) {
+  counterTarget.value = neg
+  counterForm.value = {
+    amount: String(neg.amount),
+    pricePerUnitAmount: String(neg.pricePerUnit.amount),
+    premiumAmount: String(neg.premium.amount),
+    settlementDate: neg.settlementDate,
+  }
+  counterError.value = ''
+}
+
+function closeCounterForm() {
+  counterTarget.value = null
+}
+
+async function submitCounter() {
+  if (!counterTarget.value) return
+  const target = counterTarget.value
+  const payload: CounterInterbankNegotiationPayload = {
+    stock: { ticker: target.stock.ticker },
+    settlementDate: counterForm.value.settlementDate,
+    pricePerUnit: { currency: target.pricePerUnit.currency, amount: Number(counterForm.value.pricePerUnitAmount) },
+    premium: { currency: target.premium.currency, amount: Number(counterForm.value.premiumAmount) },
+    amount: Number(counterForm.value.amount),
+  }
+  counterSubmitting.value = true
+  counterError.value = ''
+  try {
+    await interbankOtcApi.counterNegotiation(target.negotiationRoutingNumber, target.negotiationId, payload)
+    closeCounterForm()
+    await loadNegotiations()
+  } catch (e: any) {
+    counterError.value = e?.response?.data?.message || 'Greška pri slanju kontra-ponude.'
+  } finally {
+    counterSubmitting.value = false
+  }
+}
+
+const acceptingId = ref('')
+async function acceptNegotiation(neg: InterbankNegotiation) {
+  if (!confirm(`Prihvatiti ovaj pregovor za ${neg.amount} ${neg.stock.ticker}?`)) return
+  acceptingId.value = neg.negotiationId
+  try {
+    await interbankOtcApi.acceptNegotiation(neg.negotiationRoutingNumber, neg.negotiationId)
+    await Promise.all([loadNegotiations(), loadContracts()])
+  } catch (e: any) {
+    alert(e?.response?.data?.message || 'Greška pri prihvatanju pregovora.')
+  } finally {
+    acceptingId.value = ''
+  }
+}
+
+const closingId = ref('')
+async function closeNegotiation(neg: InterbankNegotiation) {
+  if (!confirm('Zatvoriti ovaj pregovor?')) return
+  closingId.value = neg.negotiationId
+  try {
+    await interbankOtcApi.closeNegotiation(neg.negotiationRoutingNumber, neg.negotiationId)
+    await loadNegotiations()
+  } catch (e: any) {
+    alert(e?.response?.data?.message || 'Greška pri zatvaranju pregovora.')
+  } finally {
+    closingId.value = ''
+  }
+}
+
+// ─── Option contracts ──────────────────────────────────────────────────
+const contracts = ref<InterbankOptionContract[]>([])
+const contractsLoading = ref(false)
+const contractsError = ref('')
+
+async function loadContracts() {
+  contractsLoading.value = true
+  contractsError.value = ''
+  try {
+    const res = await interbankOtcApi.listOptionContracts()
+    contracts.value = res.data.contracts ?? []
+  } catch (e: any) {
+    contractsError.value = e?.response?.data?.message || 'Greška pri učitavanju opcionih ugovora.'
+  } finally {
+    contractsLoading.value = false
+  }
+}
+
+const exercisingId = ref(0)
+const exerciseFeedback = ref('')
+const exerciseFeedbackClass = ref<'ok' | 'err'>('ok')
+
+async function exerciseContract(c: InterbankOptionContract) {
+  if (!confirm(`Iskoristiti opciju za ${c.amount} ${c.stockTicker}? Cena: ${c.pricePerUnit.amount * c.amount} ${c.pricePerUnit.currency}.`)) return
+  exercisingId.value = c.id
+  exerciseFeedback.value = ''
+  try {
+    const res = await interbankOtcApi.exerciseOptionContract(c.id)
+    if (res.data.status === 'committed') {
+      exerciseFeedback.value = 'Opcija uspešno izvršena.'
+      exerciseFeedbackClass.value = 'ok'
+    } else {
+      exerciseFeedback.value = res.data.message || `Izvršavanje opcije: ${res.data.status}`
+      exerciseFeedbackClass.value = 'err'
+    }
+    await loadContracts()
+  } catch (e: any) {
+    exerciseFeedback.value = e?.response?.data?.message || 'Greška pri izvršavanju opcije.'
+    exerciseFeedbackClass.value = 'err'
+  } finally {
+    exercisingId.value = 0
+  }
+}
+
+// ─── Helpers ───────────────────────────────────────────────────────────
+const moneyFmt = new Intl.NumberFormat('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })
+const qtyFmt = new Intl.NumberFormat('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 2 })
+
+function fmt(v: number) { return moneyFmt.format(v) }
+function fmtQty(v: number) { return qtyFmt.format(v) }
+function fmtDate(iso: string) {
+  if (!iso) return '—'
+  return new Date(iso).toLocaleString('sr-RS')
+}
+
+const partnerErrorEntries = computed(() => Object.entries(partnerErrors.value))
+const hasPartnerStale = computed(() => Object.keys(partnerStale.value).length > 0)
+
+onMounted(async () => {
+  await Promise.all([loadStocks(), loadNegotiations(), loadContracts()])
+})
+</script>
+
+<template>
+  <div class="ib-page">
+    <header class="ib-header">
+      <h1>Cross-bank OTC</h1>
+      <p class="ib-sub">
+        Tržište javnih akcija, pregovori i opcioni ugovori između banaka u sistemu.
+      </p>
+    </header>
+
+    <nav class="ib-tabs">
+      <button :class="{ active: activeTab === 'stocks' }" @click="activeTab = 'stocks'">
+        Javne akcije banaka
+      </button>
+      <button :class="{ active: activeTab === 'negotiations' }" @click="activeTab = 'negotiations'">
+        Pregovori
+        <span v-if="negotiations.length" class="ib-badge">{{ negotiations.length }}</span>
+      </button>
+      <button :class="{ active: activeTab === 'contracts' }" @click="activeTab = 'contracts'">
+        Opcioni ugovori
+        <span v-if="contracts.length" class="ib-badge">{{ contracts.length }}</span>
+      </button>
+    </nav>
+
+    <!-- ─── PUBLIC STOCKS ─────────────────────────────────────────── -->
+    <section v-if="activeTab === 'stocks'" class="ib-card">
+      <div class="ib-card-head">
+        <div>
+          <h2>Javne akcije partnerskih banaka</h2>
+          <div class="ib-meta">
+            Izvor: <strong>{{ stocksSource === 'cache' ? 'keš' : 'uživo' }}</strong>
+            <span v-if="hasPartnerStale" class="ib-warn">· deo podataka može biti zastareo</span>
+          </div>
+        </div>
+        <button class="ib-btn ib-btn-sec" :disabled="stocksLoading" @click="loadStocks(true)">
+          {{ stocksLoading ? 'Osvežavam…' : 'Osveži uživo' }}
+        </button>
+      </div>
+
+      <div v-if="partnerErrorEntries.length" class="ib-warn-box">
+        <strong>Neke banke nedostupne:</strong>
+        <ul>
+          <li v-for="[routing, err] in partnerErrorEntries" :key="routing">
+            Banka {{ routing }} — {{ err }}
+          </li>
+        </ul>
+      </div>
+
+      <div v-if="stocksError" class="ib-error">{{ stocksError }}</div>
+
+      <div v-if="!stocksLoading && stocks.length === 0" class="ib-empty">
+        Nema javnih akcija u partnerskim bankama.
+      </div>
+
+      <table v-else class="ib-table">
+        <thead>
+          <tr>
+            <th>Ticker</th>
+            <th>Prodavac (banka)</th>
+            <th>Dostupna količina</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          <template v-for="stock in stocks" :key="stock.ticker">
+            <tr v-for="seller in stock.sellers" :key="`${stock.ticker}-${seller.bankRoutingNumber}-${seller.sellerId}`">
+              <td class="ib-mono">{{ stock.ticker }}</td>
+              <td>
+                <span class="ib-chip">{{ seller.bankDisplayName || `Banka ${seller.bankRoutingNumber}` }}</span>
+                <span class="ib-mono ib-faded">· {{ seller.sellerId }}</span>
+              </td>
+              <td>{{ fmtQty(seller.amount) }}</td>
+              <td>
+                <button class="ib-btn ib-btn-primary" @click="openOfferForm(stock, seller)">
+                  Pošalji ponudu
+                </button>
+              </td>
+            </tr>
+          </template>
+        </tbody>
+      </table>
+    </section>
+
+    <!-- ─── NEGOTIATIONS ──────────────────────────────────────────── -->
+    <section v-if="activeTab === 'negotiations'" class="ib-card">
+      <div class="ib-card-head">
+        <h2>Moji pregovori</h2>
+        <div class="ib-filters">
+          <select v-model="negotiationsFilter" @change="loadNegotiations()">
+            <option value="">Svi</option>
+            <option value="buyer">Kao kupac</option>
+            <option value="seller">Kao prodavac</option>
+          </select>
+          <label class="ib-check">
+            <input type="checkbox" v-model="includeClosed" @change="loadNegotiations()" />
+            Prikaži zatvorene
+          </label>
+          <button class="ib-btn ib-btn-sec" :disabled="negotiationsLoading" @click="loadNegotiations()">
+            Osveži
+          </button>
+        </div>
+      </div>
+
+      <div v-if="negotiationsError" class="ib-error">{{ negotiationsError }}</div>
+      <div v-if="!negotiationsLoading && negotiations.length === 0" class="ib-empty">
+        Nema pregovora.
+      </div>
+
+      <table v-else class="ib-table">
+        <thead>
+          <tr>
+            <th>Ticker</th>
+            <th>Uloga</th>
+            <th>Druga strana</th>
+            <th>Količina</th>
+            <th>Cena</th>
+            <th>Premija</th>
+            <th>Settlement</th>
+            <th>Status</th>
+            <th>Poslednju izmenu napravio</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="neg in negotiations" :key="`${neg.negotiationRoutingNumber}-${neg.negotiationId}`">
+            <td class="ib-mono">{{ neg.stock.ticker }}</td>
+            <td><span class="ib-chip">{{ neg.localRole === 'buyer' ? 'Kupac' : 'Prodavac' }}</span></td>
+            <td>
+              <span class="ib-chip">Banka {{ neg.counterpartyRoutingNumber }}</span>
+            </td>
+            <td>{{ fmtQty(neg.amount) }}</td>
+            <td>{{ fmt(neg.pricePerUnit.amount) }} {{ neg.pricePerUnit.currency }}</td>
+            <td>{{ fmt(neg.premium.amount) }} {{ neg.premium.currency }}</td>
+            <td>{{ neg.settlementDate }}</td>
+            <td>
+              <span :class="['ib-status', neg.isOngoing ? 'ib-status-ongoing' : 'ib-status-closed']">
+                {{ neg.isOngoing ? 'U toku' : 'Zatvoren' }}
+              </span>
+            </td>
+            <td>
+              {{ neg.lastModifiedBy.routingNumber === neg.buyerId.routingNumber && neg.lastModifiedBy.id === neg.buyerId.id ? 'Kupac' : 'Prodavac' }}
+            </td>
+            <td v-if="neg.isOngoing" class="ib-actions">
+              <button class="ib-btn ib-btn-sec" @click="openCounterForm(neg)">Kontra</button>
+              <button
+                class="ib-btn ib-btn-primary"
+                :disabled="acceptingId === neg.negotiationId || (neg.lastModifiedBy.routingNumber === (neg.localRole === 'buyer' ? neg.buyerId.routingNumber : neg.sellerId.routingNumber) && neg.lastModifiedBy.id === (neg.localRole === 'buyer' ? neg.buyerId.id : neg.sellerId.id))"
+                @click="acceptNegotiation(neg)"
+              >
+                {{ acceptingId === neg.negotiationId ? '…' : 'Prihvati' }}
+              </button>
+              <button class="ib-btn ib-btn-danger" :disabled="closingId === neg.negotiationId" @click="closeNegotiation(neg)">
+                {{ closingId === neg.negotiationId ? '…' : 'Zatvori' }}
+              </button>
+            </td>
+            <td v-else></td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <!-- ─── OPTION CONTRACTS ──────────────────────────────────────── -->
+    <section v-if="activeTab === 'contracts'" class="ib-card">
+      <div class="ib-card-head">
+        <h2>Cross-bank opcioni ugovori</h2>
+        <button class="ib-btn ib-btn-sec" :disabled="contractsLoading" @click="loadContracts()">Osveži</button>
+      </div>
+
+      <div v-if="contractsError" class="ib-error">{{ contractsError }}</div>
+      <div v-if="exerciseFeedback" :class="['ib-feedback', exerciseFeedbackClass === 'ok' ? 'ib-feedback-ok' : 'ib-feedback-err']">
+        {{ exerciseFeedback }}
+      </div>
+      <div v-if="!contractsLoading && contracts.length === 0" class="ib-empty">
+        Nemate cross-bank opcione ugovore.
+      </div>
+
+      <table v-else class="ib-table">
+        <thead>
+          <tr>
+            <th>Ticker</th>
+            <th>Prodavac (banka)</th>
+            <th>Količina</th>
+            <th>Cena izvršenja</th>
+            <th>Premija</th>
+            <th>Settlement</th>
+            <th>Status</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="c in contracts" :key="c.id">
+            <td class="ib-mono">{{ c.stockTicker }}</td>
+            <td>
+              <span class="ib-chip">Banka {{ c.sellerRoutingNumber }}</span>
+              <span class="ib-mono ib-faded">· {{ c.sellerId }}</span>
+            </td>
+            <td>{{ fmtQty(c.amount) }}</td>
+            <td>{{ fmt(c.pricePerUnit.amount) }} {{ c.pricePerUnit.currency }}</td>
+            <td>{{ fmt(c.premium.amount) }} {{ c.premium.currency }}</td>
+            <td>{{ c.settlementDate }}</td>
+            <td>
+              <span :class="['ib-status', `ib-status-${c.status}`]">{{ c.status }}</span>
+            </td>
+            <td>
+              <button
+                v-if="c.status === 'valid'"
+                class="ib-btn ib-btn-primary"
+                :disabled="exercisingId === c.id"
+                @click="exerciseContract(c)"
+              >
+                {{ exercisingId === c.id ? 'Izvršavam…' : 'Iskoristi' }}
+              </button>
+              <span v-else class="ib-faded">—</span>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <div class="ib-meta" style="margin-top:8px">
+        Posl. ažuriranje: {{ contracts[0] ? fmtDate(contracts[0].updatedAt) : '—' }}
+      </div>
+    </section>
+
+    <!-- ─── OFFER MODAL ───────────────────────────────────────────── -->
+    <div v-if="showOfferForm && offerSeller" class="ib-modal-bg" @click.self="closeOfferForm">
+      <div class="ib-modal">
+        <h3>Nova ponuda · {{ offerTicker }}</h3>
+        <div class="ib-meta">
+          Prodavac: <span class="ib-chip">{{ offerSeller.bankDisplayName }}</span>
+          <span class="ib-mono ib-faded">· {{ offerSeller.sellerId }}</span>
+          <span> · dostupno: {{ fmtQty(offerSeller.amount) }}</span>
+        </div>
+
+        <div class="ib-field">
+          <label>Količina</label>
+          <input type="number" v-model="offerForm.amount" :max="offerSeller.amount" min="1" />
+        </div>
+        <div class="ib-row">
+          <div class="ib-field">
+            <label>Cena po akciji</label>
+            <input type="number" v-model="offerForm.pricePerUnitAmount" min="0.01" step="0.01" />
+          </div>
+          <div class="ib-field ib-field-sm">
+            <label>Valuta</label>
+            <select v-model="offerForm.pricePerUnitCurrency">
+              <option>USD</option><option>EUR</option><option>RSD</option>
+            </select>
+          </div>
+        </div>
+        <div class="ib-row">
+          <div class="ib-field">
+            <label>Premija (ukupno)</label>
+            <input type="number" v-model="offerForm.premiumAmount" min="0" step="0.01" />
+          </div>
+          <div class="ib-field ib-field-sm">
+            <label>Valuta</label>
+            <select v-model="offerForm.premiumCurrency">
+              <option>USD</option><option>EUR</option><option>RSD</option>
+            </select>
+          </div>
+        </div>
+        <div class="ib-field">
+          <label>Settlement date</label>
+          <input type="date" v-model="offerForm.settlementDate" />
+        </div>
+
+        <div v-if="offerError" class="ib-error">{{ offerError }}</div>
+        <div class="ib-modal-actions">
+          <button class="ib-btn ib-btn-sec" @click="closeOfferForm">Otkaži</button>
+          <button class="ib-btn ib-btn-primary" :disabled="offerSubmitting" @click="submitOffer">
+            {{ offerSubmitting ? 'Šaljem…' : 'Pošalji ponudu' }}
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- ─── COUNTER MODAL ─────────────────────────────────────────── -->
+    <div v-if="counterTarget" class="ib-modal-bg" @click.self="closeCounterForm">
+      <div class="ib-modal">
+        <h3>Kontra-ponuda · {{ counterTarget.stock.ticker }}</h3>
+        <div class="ib-field">
+          <label>Količina</label>
+          <input type="number" v-model="counterForm.amount" min="1" />
+        </div>
+        <div class="ib-field">
+          <label>Cena po akciji ({{ counterTarget.pricePerUnit.currency }})</label>
+          <input type="number" v-model="counterForm.pricePerUnitAmount" min="0.01" step="0.01" />
+        </div>
+        <div class="ib-field">
+          <label>Premija ({{ counterTarget.premium.currency }})</label>
+          <input type="number" v-model="counterForm.premiumAmount" min="0" step="0.01" />
+        </div>
+        <div class="ib-field">
+          <label>Settlement date</label>
+          <input type="date" v-model="counterForm.settlementDate" />
+        </div>
+        <div v-if="counterError" class="ib-error">{{ counterError }}</div>
+        <div class="ib-modal-actions">
+          <button class="ib-btn ib-btn-sec" @click="closeCounterForm">Otkaži</button>
+          <button class="ib-btn ib-btn-primary" :disabled="counterSubmitting" @click="submitCounter">
+            {{ counterSubmitting ? 'Šaljem…' : 'Pošalji kontra' }}
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.ib-page { padding: 32px; max-width: 1200px; margin: 0 auto; }
+.ib-header { margin-bottom: 20px; }
+.ib-header h1 { font-size: 28px; font-weight: 700; color: #0f172a; margin: 0; }
+.ib-sub { color: #64748b; font-size: 14px; margin: 4px 0 0; }
+
+.ib-tabs { display: flex; gap: 4px; margin-bottom: 20px; border-bottom: 1px solid #e2e8f0; }
+.ib-tabs button {
+  padding: 10px 16px; background: none; border: none; cursor: pointer;
+  font-size: 14px; font-weight: 600; color: #64748b;
+  border-bottom: 2px solid transparent; transition: all 0.15s;
+}
+.ib-tabs button:hover { color: #0f172a; }
+.ib-tabs button.active { color: #2563eb; border-bottom-color: #2563eb; }
+.ib-badge {
+  display: inline-block; padding: 2px 8px; margin-left: 6px;
+  background: #e0e7ff; color: #3730a3; border-radius: 999px;
+  font-size: 11px; font-weight: 700;
+}
+
+.ib-card {
+  background: #fff; border-radius: 16px; padding: 24px;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.06), 0 8px 24px rgba(0,0,0,0.04);
+  border: 1px solid #e2e8f0;
+}
+.ib-card-head {
+  display: flex; justify-content: space-between; align-items: flex-start;
+  gap: 16px; margin-bottom: 16px;
+}
+.ib-card-head h2 { font-size: 18px; color: #0f172a; margin: 0 0 4px; }
+.ib-meta { font-size: 13px; color: #64748b; }
+.ib-warn { color: #b45309; margin-left: 4px; }
+
+.ib-filters { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
+.ib-filters select, .ib-check {
+  padding: 6px 10px; border: 1px solid #d1d5db; border-radius: 8px;
+  font-size: 13px; background: #fff;
+}
+.ib-check { display: flex; align-items: center; gap: 6px; cursor: pointer; }
+
+.ib-table {
+  width: 100%; border-collapse: collapse; font-size: 14px;
+}
+.ib-table th {
+  text-align: left; padding: 10px 12px;
+  background: #f8fafc; color: #475569; font-size: 12px;
+  text-transform: uppercase; letter-spacing: 0.5px; font-weight: 700;
+  border-bottom: 1px solid #e2e8f0;
+}
+.ib-table td {
+  padding: 12px; border-bottom: 1px solid #f1f5f9; vertical-align: middle;
+}
+.ib-table tr:hover td { background: #fafbfc; }
+
+.ib-mono { font-family: 'SF Mono', ui-monospace, monospace; }
+.ib-faded { color: #94a3b8; }
+
+.ib-chip {
+  display: inline-block; padding: 3px 10px; border-radius: 999px;
+  background: #eef2ff; color: #3730a3; font-size: 12px; font-weight: 600;
+}
+
+.ib-status {
+  display: inline-block; padding: 3px 10px; border-radius: 999px;
+  font-size: 11px; font-weight: 700; text-transform: uppercase;
+}
+.ib-status-ongoing  { background: #fef9c3; color: #854d0e; }
+.ib-status-closed   { background: #f1f5f9; color: #475569; }
+.ib-status-valid    { background: #dcfce7; color: #166534; }
+.ib-status-exercised{ background: #e0e7ff; color: #3730a3; }
+.ib-status-expired  { background: #f1f5f9; color: #475569; }
+
+.ib-actions { display: flex; gap: 6px; flex-wrap: wrap; }
+
+.ib-btn {
+  padding: 8px 14px; border-radius: 8px; font-size: 13px; font-weight: 600;
+  cursor: pointer; border: none; transition: all 0.15s;
+}
+.ib-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+.ib-btn-primary { background: #2563eb; color: #fff; }
+.ib-btn-primary:hover:not(:disabled) { background: #1d4ed8; }
+.ib-btn-sec { background: #f1f5f9; color: #475569; }
+.ib-btn-sec:hover:not(:disabled) { background: #e2e8f0; }
+.ib-btn-danger { background: #fef2f2; color: #b91c1c; }
+.ib-btn-danger:hover:not(:disabled) { background: #fee2e2; }
+
+.ib-warn-box {
+  padding: 10px 14px; background: #fffbeb; border: 1px solid #fde68a;
+  border-radius: 8px; color: #92400e; font-size: 13px; margin-bottom: 12px;
+}
+.ib-warn-box ul { margin: 4px 0 0; padding-left: 18px; }
+
+.ib-error {
+  padding: 10px 14px; background: #fef2f2; color: #dc2626;
+  border-radius: 8px; font-size: 13px; margin-bottom: 12px;
+}
+
+.ib-feedback { padding: 10px 14px; border-radius: 8px; font-size: 13px; margin-bottom: 12px; }
+.ib-feedback-ok  { background: #dcfce7; color: #166534; }
+.ib-feedback-err { background: #fef2f2; color: #b91c1c; }
+
+.ib-empty {
+  text-align: center; padding: 32px; color: #94a3b8; font-size: 14px;
+}
+
+/* modal */
+.ib-modal-bg {
+  position: fixed; inset: 0; background: rgba(15,23,42,0.5);
+  display: flex; align-items: center; justify-content: center; z-index: 50;
+}
+.ib-modal {
+  background: #fff; border-radius: 16px; padding: 24px;
+  max-width: 480px; width: 90%;
+  box-shadow: 0 20px 50px rgba(0,0,0,0.2);
+}
+.ib-modal h3 { font-size: 18px; margin: 0 0 12px; color: #0f172a; }
+.ib-field { margin-bottom: 12px; display: flex; flex-direction: column; gap: 4px; }
+.ib-field label { font-size: 12px; font-weight: 600; color: #475569; }
+.ib-field input, .ib-field select {
+  padding: 9px 12px; border: 1px solid #d1d5db; border-radius: 8px;
+  font-size: 14px;
+}
+.ib-row { display: flex; gap: 8px; }
+.ib-row .ib-field { flex: 1; }
+.ib-row .ib-field-sm { flex: 0 0 100px; }
+.ib-modal-actions { display: flex; gap: 8px; margin-top: 16px; justify-content: flex-end; }
+</style>

--- a/src/views/client/ClientLayout.vue
+++ b/src/views/client/ClientLayout.vue
@@ -58,6 +58,10 @@ function isPaymentSection() {
           OTC ponude
         </RouterLink>
 
+        <RouterLink v-if="canAccessMarket" to="/client/otc/interbank" class="sidebar-sublink" :class="{ active: isActive('/client/otc/interbank') }">
+          Cross-bank OTC
+        </RouterLink>
+
         <RouterLink to="/client/funds" class="sidebar-link" :class="{ active: isActive('/client/funds') }">
           <span class="sidebar-icon">F</span><span>Fondovi</span>
         </RouterLink>

--- a/src/views/client/ClientNewPaymentView.vue
+++ b/src/views/client/ClientNewPaymentView.vue
@@ -1,12 +1,13 @@
 <script setup lang="ts">
 import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
-import { validateAccountNumber } from '../../utils/accountValidation'
+import { validateAccountNumber, isCrossBankAccount, bankNameOf } from '../../utils/accountValidation'
 import { useRouter } from 'vue-router'
 import { useClientAuthStore } from '../../stores/clientAuth'
 import { useClientAccountStore } from '../../stores/clientAccount'
 import { useRecipientStore } from '../../stores/recipient'
 import { usePaymentStore } from '../../stores/payment'
-import { SIFRE_PLACANJA } from '../../api/payment'
+import { SIFRE_PLACANJA, crossBankPaymentApi } from '../../api/payment'
+import type { CrossBankPaymentResponse } from '../../api/payment'
 import { recipientApi } from '../../api/recipient'
 import type { PaymentItem } from '../../api/payment'
 
@@ -18,7 +19,12 @@ const paymentStore = usePaymentStore()
 
 const clientId = computed(() => String(clientAuthStore.client?.id ?? ''))
 
-const step = ref<'form' | 'confirm' | 'verify' | 'success'>('form')
+const step = ref<'form' | 'confirm' | 'verify' | 'crossbank' | 'success'>('form')
+
+const crossBankPayment = ref<CrossBankPaymentResponse | null>(null)
+const crossBankError = ref('')
+const crossBankSubmitting = ref(false)
+let crossBankPollTimer: ReturnType<typeof setInterval> | null = null
 
 const form = ref({
   fromAccountId: '',
@@ -116,6 +122,9 @@ const isNewRecipient = computed(() => {
   return !recipientStore.recipients.some(r => r.brojRacuna === receiverBrojRacuna.value)
 })
 
+const isCrossBank = computed(() => isCrossBankAccount(receiverBrojRacuna.value))
+const recipientBankLabel = computed(() => bankNameOf(receiverBrojRacuna.value))
+
 function goToConfirm() {
   formError.value = ''
   if (!form.value.fromAccountId) { formError.value = 'Izaberite račun platioca.'; return }
@@ -140,6 +149,10 @@ function goToConfirmSecure() {
 void goToConfirm
 
 async function handleSubmit() {
+  if (isCrossBank.value) {
+    await handleCrossBankSubmit()
+    return
+  }
   try {
     const payment = await paymentStore.createPayment({
       racunPosiljaocaId: Number(form.value.fromAccountId),
@@ -156,6 +169,65 @@ async function handleSubmit() {
   } catch (e: any) {
     formError.value = e.response?.data?.message || 'Greška pri kreiranju plaćanja.'
     step.value = 'form'
+  }
+}
+
+async function handleCrossBankSubmit() {
+  const sender = fromAccount.value
+  if (!sender) { formError.value = 'Izaberite račun platioca.'; return }
+  crossBankError.value = ''
+  crossBankSubmitting.value = true
+  crossBankPayment.value = null
+  step.value = 'crossbank'
+  try {
+    const res = await crossBankPaymentApi.create({
+      senderAccountNumber: sender.brojRacuna,
+      recipientAccountNumber: receiverBrojRacuna.value,
+      currency: sender.currencyKod,
+      amount: Number(form.value.iznos),
+      message: form.value.svrha,
+      paymentCode: form.value.sifraPlacanja,
+      paymentPurpose: form.value.svrha,
+    })
+    crossBankPayment.value = res.data.payment as CrossBankPaymentResponse
+    if (crossBankPayment.value?.status === 'pending') {
+      startCrossBankPoll(crossBankPayment.value.id)
+    } else {
+      await accountStore.fetchAccounts(clientId.value)
+    }
+  } catch (e: any) {
+    const data = e?.response?.data
+    crossBankPayment.value = (data?.payment as CrossBankPaymentResponse) ?? null
+    crossBankError.value = data?.message || 'Greška pri kreiranju prekograničnog plaćanja.'
+    if (crossBankPayment.value?.status === 'pending' && crossBankPayment.value?.id) {
+      startCrossBankPoll(crossBankPayment.value.id)
+    }
+  } finally {
+    crossBankSubmitting.value = false
+  }
+}
+
+function startCrossBankPoll(id: number) {
+  stopCrossBankPoll()
+  crossBankPollTimer = setInterval(async () => {
+    try {
+      const res = await crossBankPaymentApi.get(id)
+      const p = res.data.payment as CrossBankPaymentResponse
+      crossBankPayment.value = p
+      if (p.status !== 'pending') {
+        stopCrossBankPoll()
+        await accountStore.fetchAccounts(clientId.value)
+      }
+    } catch {
+      // transient — keep polling
+    }
+  }, 2000)
+}
+
+function stopCrossBankPoll() {
+  if (crossBankPollTimer) {
+    clearInterval(crossBankPollTimer)
+    crossBankPollTimer = null
   }
 }
 
@@ -242,11 +314,16 @@ function startNew() {
   verifySecondsLeft.value = 300
   codeExpired.value = false
   failedAttempts.value = 0
+  crossBankPayment.value = null
+  crossBankError.value = ''
+  crossBankSubmitting.value = false
+  stopCrossBankPoll()
   step.value = 'form'
 }
 
 onUnmounted(() => {
   if (verifyTimerInterval) clearInterval(verifyTimerInterval)
+  stopCrossBankPoll()
 })
 
 onMounted(async () => {
@@ -294,6 +371,10 @@ onMounted(async () => {
           />
           <div v-else class="pay-readonly">
             {{ receiverBrojRacuna || 'Izaberite primaoca iz liste' }}
+          </div>
+          <div v-if="isCrossBank" class="pay-bank-chip">
+            <span class="pay-bank-chip-dot">●</span>
+            Prekogranično plaćanje · {{ recipientBankLabel }}
           </div>
         </div>
 
@@ -376,12 +457,105 @@ onMounted(async () => {
             <span>Sa računa</span>
             <span class="pay-mono">{{ fromAccount?.brojRacuna }}</span>
           </div>
+          <div v-if="isCrossBank" class="pay-summary-row">
+            <span>Tip plaćanja</span>
+            <span class="pay-bank-chip pay-bank-chip-inline">Prekogranično · {{ recipientBankLabel }}</span>
+          </div>
         </div>
         <div v-if="formError" class="pay-error">{{ formError }}</div>
+        <div v-if="isCrossBank" class="pay-info-note">
+          Plaćanje se izvršava 2-faznim protokolom između banaka. Bez verifikacionog koda — banka primaoca odlučuje.
+        </div>
         <div class="pay-actions">
           <button class="pay-btn pay-btn-sec" @click="step = 'form'">Nazad</button>
-          <button class="pay-btn pay-btn-primary" :disabled="paymentStore.loading" @click="handleSubmit">
-            {{ paymentStore.loading ? 'Šaljem...' : 'Potvrdi' }}
+          <button class="pay-btn pay-btn-primary" :disabled="paymentStore.loading || crossBankSubmitting" @click="handleSubmit">
+            {{ (paymentStore.loading || crossBankSubmitting) ? 'Šaljem...' : 'Potvrdi' }}
+          </button>
+        </div>
+      </div>
+
+      <!-- CROSS-BANK 2PC PROGRESS -->
+      <div v-else-if="step === 'crossbank'">
+        <div class="pay-section-label">Prekogranično plaćanje · {{ recipientBankLabel }}</div>
+
+        <div class="pay-saga-steps">
+          <div class="pay-saga-step" :class="{ 'pay-saga-active': crossBankSubmitting, 'pay-saga-done': !crossBankSubmitting }">
+            <div class="pay-saga-icon">{{ crossBankSubmitting ? '⏳' : '✓' }}</div>
+            <div class="pay-saga-label">
+              <strong>1. Rezervacija sredstava</strong>
+              <div class="pay-saga-sub">Iznos je rezervisan na Vašem računu.</div>
+            </div>
+          </div>
+          <div class="pay-saga-step" :class="{
+            'pay-saga-active': crossBankSubmitting,
+            'pay-saga-done': !crossBankSubmitting && crossBankPayment && crossBankPayment.status !== 'pending' && crossBankPayment.status !== 'failed',
+            'pay-saga-fail': crossBankPayment && (crossBankPayment.status === 'rejected' || crossBankPayment.status === 'failed'),
+          }">
+            <div class="pay-saga-icon">
+              <span v-if="crossBankSubmitting">⏳</span>
+              <span v-else-if="crossBankPayment?.status === 'rejected' || crossBankPayment?.status === 'failed'">✗</span>
+              <span v-else-if="crossBankPayment?.status === 'committed'">✓</span>
+              <span v-else>⋯</span>
+            </div>
+            <div class="pay-saga-label">
+              <strong>2. Glasanje banke primaoca</strong>
+              <div class="pay-saga-sub">{{ recipientBankLabel }} odlučuje da li prihvata plaćanje.</div>
+            </div>
+          </div>
+          <div class="pay-saga-step" :class="{
+            'pay-saga-done': crossBankPayment?.status === 'committed',
+            'pay-saga-fail': crossBankPayment?.status === 'rejected' || crossBankPayment?.status === 'failed',
+            'pay-saga-active': crossBankPayment?.status === 'pending' && !crossBankSubmitting,
+          }">
+            <div class="pay-saga-icon">
+              <span v-if="crossBankPayment?.status === 'committed'">✓</span>
+              <span v-else-if="crossBankPayment?.status === 'rejected' || crossBankPayment?.status === 'failed'">✗</span>
+              <span v-else-if="crossBankPayment?.status === 'pending'">⏳</span>
+              <span v-else>⋯</span>
+            </div>
+            <div class="pay-saga-label">
+              <strong>3. Finalizacija (commit / rollback)</strong>
+              <div class="pay-saga-sub">
+                <template v-if="crossBankPayment?.status === 'committed'">Sredstva su uspešno preneta.</template>
+                <template v-else-if="crossBankPayment?.status === 'rejected'">Plaćanje odbijeno — sredstva oslobođena.</template>
+                <template v-else-if="crossBankPayment?.status === 'failed'">Greška u protokolu — sredstva oslobođena.</template>
+                <template v-else>Čeka se odgovor partner banke…</template>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div v-if="crossBankPayment" class="pay-saga-summary">
+          <div class="pay-summary-row">
+            <span>Status</span>
+            <span :class="['pay-status-badge', `pay-status-${crossBankPayment.status}`]">
+              {{ crossBankPayment.status }}
+            </span>
+          </div>
+          <div class="pay-summary-row">
+            <span>Iznos</span>
+            <span>{{ crossBankPayment.amount.toLocaleString('sr-RS', { minimumFractionDigits: 2 }) }} {{ crossBankPayment.currency }}</span>
+          </div>
+          <div class="pay-summary-row">
+            <span>Račun primaoca</span>
+            <span class="pay-mono">{{ crossBankPayment.recipientAccountNumber }}</span>
+          </div>
+          <div class="pay-summary-row" v-if="crossBankPayment.lastError">
+            <span>Razlog</span>
+            <span>{{ crossBankPayment.lastError }}</span>
+          </div>
+        </div>
+
+        <div v-if="crossBankError && (!crossBankPayment || crossBankPayment.status === 'failed')" class="pay-error">
+          {{ crossBankError }}
+        </div>
+
+        <div class="pay-actions">
+          <button class="pay-btn pay-btn-sec" :disabled="crossBankSubmitting || crossBankPayment?.status === 'pending'" @click="router.push('/client/payments')">
+            Pregled plaćanja
+          </button>
+          <button class="pay-btn pay-btn-primary" :disabled="crossBankSubmitting || crossBankPayment?.status === 'pending'" @click="startNew">
+            Novo plaćanje
           </button>
         </div>
       </div>
@@ -568,4 +742,54 @@ onMounted(async () => {
   margin-top: 16px; padding: 12px 16px; background: #dcfce7;
   border-radius: 8px; color: #166534; font-size: 14px; font-weight: 500;
 }
+
+/* Cross-bank chip + info */
+.pay-bank-chip {
+  display: inline-flex; align-items: center; gap: 6px;
+  margin-top: 4px; padding: 4px 10px; border-radius: 999px;
+  background: #ecfeff; color: #155e75; border: 1px solid #a5f3fc;
+  font-size: 12px; font-weight: 600;
+}
+.pay-bank-chip-dot { color: #06b6d4; font-size: 10px; }
+.pay-bank-chip-inline { margin-top: 0; }
+.pay-info-note {
+  padding: 10px 14px; background: #f0f9ff; color: #075985;
+  border: 1px solid #bae6fd; border-radius: 8px;
+  font-size: 13px; margin-bottom: 12px;
+}
+
+/* 2PC SAGA-style progress */
+.pay-saga-steps { display: flex; flex-direction: column; gap: 12px; margin-bottom: 20px; }
+.pay-saga-step {
+  display: flex; align-items: flex-start; gap: 12px;
+  padding: 12px 14px; border-radius: 10px;
+  background: #f8fafc; border: 1px solid #e2e8f0;
+  opacity: 0.6; transition: all 0.2s;
+}
+.pay-saga-step.pay-saga-active { opacity: 1; background: #eff6ff; border-color: #bfdbfe; }
+.pay-saga-step.pay-saga-done { opacity: 1; background: #f0fdf4; border-color: #bbf7d0; }
+.pay-saga-step.pay-saga-fail { opacity: 1; background: #fef2f2; border-color: #fecaca; }
+.pay-saga-icon {
+  width: 28px; height: 28px; border-radius: 50%;
+  display: flex; align-items: center; justify-content: center;
+  background: #fff; font-size: 14px; flex-shrink: 0;
+  border: 1px solid currentColor;
+}
+.pay-saga-step.pay-saga-active .pay-saga-icon { color: #2563eb; }
+.pay-saga-step.pay-saga-done .pay-saga-icon { color: #16a34a; }
+.pay-saga-step.pay-saga-fail .pay-saga-icon { color: #dc2626; }
+.pay-saga-label { font-size: 14px; color: #0f172a; }
+.pay-saga-label strong { display: block; margin-bottom: 2px; }
+.pay-saga-sub { font-size: 13px; color: #64748b; }
+
+.pay-saga-summary { margin: 16px 0; display: flex; flex-direction: column; }
+.pay-status-badge {
+  padding: 3px 10px; border-radius: 999px; font-size: 12px;
+  font-weight: 700; text-transform: uppercase;
+}
+.pay-status-pending     { background: #fef9c3; color: #854d0e; }
+.pay-status-committed   { background: #dcfce7; color: #166534; }
+.pay-status-rejected    { background: #fef2f2; color: #b91c1c; }
+.pay-status-failed      { background: #fef2f2; color: #b91c1c; }
+.pay-status-rolled_back { background: #f1f5f9; color: #475569; }
 </style>


### PR DESCRIPTION
Closes BANKA-FE-12 (cross-bank payment UI) and BANKA-FE-13 (cross-bank OTC portal).

Cross-bank payment (BANKA-FE-12)
- isCrossBankAccount / bankNameOf helpers in accountValidation.ts detect partner banks by the first 3 routing digits.
- crossBankPaymentApi in src/api/payment.ts (create / list / get).
- ClientNewPaymentView auto-routes recipients to the cross-bank flow, shows a partner-bank chip on form + confirm, and on submit replaces the verify-code step with a 2PC SAGA-style progress panel (3 phases: reservation, partner vote, finalisation). Polls GET /api/v1/payments/cross-bank/{id} every 2s until terminal status.

Cross-bank OTC portal (BANKA-FE-13)
- New src/api/interbankOtc.ts with typed clients for all /api/v1/interbank-otc/* endpoints (public-stocks, negotiations, option-contracts).
- New ClientInterbankOtcView.vue: three-tab portal
  - Javne akcije: aggregated cross-bank stock catalogue with cache/live toggle, per-partner stale/error indicators
  - Pregovori: buyer/seller filter, send-offer modal, counter / accept / close actions
  - Opcioni ugovori: list + Iskoristi (exercise) button with success / error feedback
- Route /client/otc/interbank registered; sidebar link "Cross-bank OTC" added under the OTC portal section in ClientLayout.

Verification
- vue-tsc --noEmit clean
- vite build clean (new chunk ClientInterbankOtcView ~17.6 kB / 5 kB gz)