### PR TITLE
feat(otc,orders): surface profit, margin loan, stop-limit trigger

### DIFF
--- a/src/api/order.ts
+++ b/src/api/order.ts
@@ -41,6 +41,10 @@ export interface Order {
   stopValue: number | null
   isAON: boolean
   isMargin: boolean
+  /** Outstanding bank-fronted balance for margin buys, in the account's currency. */
+  marginLoan: number
+  /** Stop-limit latch: true once the stop value has been crossed. */
+  stopTriggered: boolean
   status: OrderStatus
   isDone: boolean
   remainingPortions: number

--- a/src/api/otc.ts
+++ b/src/api/otc.ts
@@ -33,8 +33,11 @@ export interface OtcContract {
   amount: number
   strikePrice: number
   currentPrice: number
+  exercisedAtPrice: number
   premium: number
-  profit: number
+  profit: number // buyer's P&L (legacy alias for buyerProfit)
+  buyerProfit: number
+  sellerProfit: number
   settlementDate: string
   buyerId: number
   buyerType: string

--- a/src/views/EmployeeOrderReviewView.vue
+++ b/src/views/EmployeeOrderReviewView.vue
@@ -187,6 +187,8 @@ onMounted(load)
             </td>
             <td>
               <span class="order-type-pill">{{ order.orderType.replace('_', '-') }}</span>
+              <span v-if="order.isMargin" class="margin-pill" :title="`Bank loan: ${formatPrice(order.marginLoan)}`">M</span>
+              <span v-if="order.orderType === 'stop_limit' && order.stopTriggered" class="trigger-pill" title="Stop has triggered">T</span>
             </td>
             <td>
               <span :class="['direction-pill', order.direction]">
@@ -416,6 +418,30 @@ onMounted(load)
   color: #334155;
   font-size: 12px;
   font-weight: 600;
+}
+
+.margin-pill {
+  display: inline-block;
+  margin-left: 4px;
+  padding: 3px 6px;
+  border-radius: 6px;
+  background: #fef3c7;
+  color: #92400e;
+  font-size: 11px;
+  font-weight: 700;
+  cursor: help;
+}
+
+.trigger-pill {
+  display: inline-block;
+  margin-left: 4px;
+  padding: 3px 6px;
+  border-radius: 6px;
+  background: #dbeafe;
+  color: #1d4ed8;
+  font-size: 11px;
+  font-weight: 700;
+  cursor: help;
 }
 
 .direction-pill {

--- a/src/views/client/ClientOtcContractsView.vue
+++ b/src/views/client/ClientOtcContractsView.vue
@@ -226,9 +226,10 @@ onMounted(() => {
               <th>Ticker</th>
               <th>Kolicina</th>
               <th>Strike cena</th>
-              <th>Trzisna cena</th>
+              <th>Trzisna / Exercise cena</th>
               <th>Premija</th>
-              <th>Profit</th>
+              <th>Profit (Buyer)</th>
+              <th>Profit (Seller)</th>
               <th>Settlement</th>
               <th>Status</th>
               <th>Buyer</th>
@@ -246,10 +247,16 @@ onMounted(() => {
               </td>
               <td>{{ fmtQuantity(contract.amount) }}</td>
               <td>{{ fmtMoney(contract.strikePrice) }}</td>
-              <td>{{ fmtMoney(contract.currentPrice) }}</td>
+              <td>
+                {{ fmtMoney(contract.status === 'exercised' ? contract.exercisedAtPrice : contract.currentPrice) }}
+                <div v-if="contract.status === 'exercised'" class="asset-meta">na trenutku exercise-a</div>
+              </td>
               <td>{{ fmtMoney(contract.premium) }}</td>
-              <td :class="profitClass(contract.profit)">
-                {{ fmtMoney(contract.profit) }} {{ contract.exchange.currency }}
+              <td :class="profitClass(contract.buyerProfit)">
+                {{ fmtMoney(contract.buyerProfit) }} {{ contract.exchange.currency }}
+              </td>
+              <td :class="profitClass(contract.sellerProfit)">
+                {{ fmtMoney(contract.sellerProfit) }} {{ contract.exchange.currency }}
               </td>
               <td>{{ new Date(contract.settlementDate).toLocaleDateString('sr-RS') }}</td>
               <td>
@@ -291,9 +298,15 @@ onMounted(() => {
           <div><span>Trzisna cena</span><strong>{{ fmtMoney(exerciseTarget.currentPrice) }} {{ exerciseTarget.exchange.currency }}</strong></div>
           <div><span>Premija</span><strong>{{ fmtMoney(exerciseTarget.premium) }} {{ exerciseTarget.exchange.currency }}</strong></div>
           <div>
-            <span>Procenjeni profit</span>
-            <strong :class="profitClass(exerciseTarget.profit)">
-              {{ fmtMoney(exerciseTarget.profit) }} {{ exerciseTarget.exchange.currency }}
+            <span>Procenjeni profit (Buyer)</span>
+            <strong :class="profitClass(exerciseTarget.buyerProfit)">
+              {{ fmtMoney(exerciseTarget.buyerProfit) }} {{ exerciseTarget.exchange.currency }}
+            </strong>
+          </div>
+          <div>
+            <span>Procenjeni profit (Seller)</span>
+            <strong :class="profitClass(exerciseTarget.sellerProfit)">
+              {{ fmtMoney(exerciseTarget.sellerProfit) }} {{ exerciseTarget.exchange.currency }}
             </strong>
           </div>
           <div><span>Settlement</span><strong>{{ new Date(exerciseTarget.settlementDate).toLocaleDateString('sr-RS') }}</strong></div>


### PR DESCRIPTION
## Summary

Mirrors the backend changes in `feat/otc-margin-stoplimit-fixes` (RAF-SI-2025/EXBanka-3-Backend#212):

- `api/otc.ts` — extend `OtcContract` with `exercisedAtPrice`, `buyerProfit`, `sellerProfit` so finalized P&L is shown for both legs.
- `api/order.ts` — extend `Order` with `marginLoan` and `stopTriggered` so the employee review screen can flag margin buys and armed stop-limits.
- `ClientOtcContractsView.vue` — replace the single Profit column with `Profit (Buyer)` and `Profit (Seller)`. Use `exercisedAtPrice` for the market column on exercised rows. Exercise modal previews both legs.
- `EmployeeOrderReviewView.vue` — add an "M" badge (tooltip shows outstanding margin loan) and a "T" badge for stop-limit orders that have armed.

## Test plan

- [x] `vue-tsc -b` exit 0
- [ ] Manual: open OTC contracts → exercised row shows separate Buyer/Seller profit and exercise-time price
- [ ] Manual: open OTC contracts → valid row still mark-to-markets live
- [ ] Manual: exercise modal previews both legs before confirming
- [ ] Manual: place a margin buy → employee review shows "M" badge with loan tooltip
- [ ] Manual: trigger a stop_limit → employee review shows "T" badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)