### PR TITLE
fix(test): payment-view tests now exercise local-bank flow

### DIFF
--- a/src/__tests__/views/ClientNewPaymentView.test.ts
+++ b/src/__tests__/views/ClientNewPaymentView.test.ts
@@ -46,13 +46,13 @@ const mockAccounts = [
 ]
 
 const mockRecipients = [
-  { id: '10', clientId: '5', naziv: 'EPS', brojRacuna: '333000000000000002' },
+  { id: '10', clientId: '5', naziv: 'EPS', brojRacuna: '111000000000000008' },
 ]
 
 const mockPayment = {
   id: 'p1',
   racunPosiljaocaId: '1',
-  racunPrimaocaBroj: '333000000000000002',
+  racunPrimaocaBroj: '111000000000000008',
   iznos: 5000,
   sifraPlacanja: '289',
   pozivNaBroj: '',
@@ -158,7 +158,7 @@ describe('ClientNewPaymentView', () => {
     await wrapper.findAll('button').find(b => b.text() === 'Nastavi')!.trigger('click')
 
     expect(wrapper.text()).toContain('Pregled naloga')
-    expect(wrapper.text()).toContain('333000000000000002')
+    expect(wrapper.text()).toContain('111000000000000008')
     expect(wrapper.text()).toContain('Struja')
   })
 


### PR DESCRIPTION
## Summary
- Seven unit tests in `src/__tests__/views/ClientNewPaymentView.test.ts` were red on CI. The mock recipient used `333…` as its account number — added before the cross-bank flow existed. The view now classifies that prefix as cross-bank, so `handleSubmit` calls the unmocked `crossBankPaymentApi.create` and the verify step is never reached.
- Switch the mock recipient (and the one corresponding text assertion) to `111000000000000008` — own-bank prefix, valid checksum — so the tests exercise the local payment flow they were written for.

## Test plan
- [x] `npm test -- src/__tests__/views/ClientNewPaymentView.test.ts --run` → 18/18 pass
- [x] `npm test -- --run` → 202/202 pass across all 20 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)