### PR TITLE
Revoke tokens on frontend logout

### DIFF
--- a/src/__tests__/stores/auth.test.ts
+++ b/src/__tests__/stores/auth.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useAuthStore } from '../../stores/auth'
+import { authApi } from '../../api/auth'
+
+vi.mock('../../api/auth', () => ({
+  authApi: {
+    login: vi.fn(),
+    logout: vi.fn(),
+  },
+}))
+
+describe('auth store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    sessionStorage.clear()
+    vi.clearAllMocks()
+  })
+
+  it('logout revokes employee tokens and clears local session', async () => {
+    vi.mocked(authApi.login).mockResolvedValueOnce({
+      data: {
+        accessToken: 'employee-access',
+        refreshToken: 'employee-refresh',
+        employee: {
+          id: '1',
+          ime: 'Petar',
+          prezime: 'Petrovic',
+          email: 'petar@bank.com',
+          username: 'petar',
+          pozicija: 'Agent',
+          permissions: ['employeeAgent'],
+        },
+      },
+    })
+    vi.mocked(authApi.logout).mockResolvedValueOnce({ data: { message: 'logged out' } })
+
+    const store = useAuthStore()
+    await store.login('petar@bank.com', 'password123')
+    store.logout()
+
+    expect(authApi.logout).toHaveBeenCalledWith('employee-access', 'employee-refresh')
+    expect(store.isLoggedIn).toBe(false)
+    expect(store.employee).toBeNull()
+    expect(sessionStorage.getItem('access_token')).toBeNull()
+    expect(sessionStorage.getItem('refresh_token')).toBeNull()
+  })
+
+  it('logout clears local session even if backend logout fails', async () => {
+    vi.mocked(authApi.login).mockResolvedValueOnce({
+      data: {
+        accessToken: 'employee-access',
+        refreshToken: 'employee-refresh',
+        employee: {
+          id: '1',
+          ime: 'Petar',
+          prezime: 'Petrovic',
+          email: 'petar@bank.com',
+          username: 'petar',
+          pozicija: 'Agent',
+          permissions: ['employeeAgent'],
+        },
+      },
+    })
+    vi.mocked(authApi.logout).mockRejectedValueOnce(new Error('redis unavailable'))
+
+    const store = useAuthStore()
+    await store.login('petar@bank.com', 'password123')
+    store.logout()
+
+    expect(store.isLoggedIn).toBe(false)
+    expect(store.employee).toBeNull()
+    expect(sessionStorage.getItem('access_token')).toBeNull()
+  })
+})

--- a/src/__tests__/stores/clientAuth.test.ts
+++ b/src/__tests__/stores/clientAuth.test.ts
@@ -6,6 +6,7 @@ import { clientAuthApi } from '../../api/clientAuth'
 vi.mock('../../api/clientAuth', () => ({
   clientAuthApi: {
     login: vi.fn(),
+    logout: vi.fn(),
   },
 }))
 
@@ -50,11 +51,14 @@ describe('clientAuth store', () => {
 
     const store = useClientAuthStore()
     await store.login('ana@gmail.com', 'password123')
+    vi.mocked(clientAuthApi.logout).mockResolvedValueOnce({ data: { message: 'logged out' } })
+
     store.logout()
 
     expect(store.accessToken).toBeNull()
     expect(store.refreshToken).toBeNull()
     expect(store.client).toBeNull()
+    expect(clientAuthApi.logout).toHaveBeenCalledWith('test-access', 'test-refresh')
   })
 
   it('isLoggedIn is false initially and true after login, false after logout', async () => {
@@ -72,8 +76,30 @@ describe('clientAuth store', () => {
     await store.login('ana@gmail.com', 'password123')
     expect(store.isLoggedIn).toBe(true)
 
+    vi.mocked(clientAuthApi.logout).mockResolvedValueOnce({ data: { message: 'logged out' } })
+
     store.logout()
     expect(store.isLoggedIn).toBe(false)
+  })
+
+  it('logout clears local state even if backend logout fails', async () => {
+    vi.mocked(clientAuthApi.login).mockResolvedValueOnce({
+      data: {
+        accessToken: 'test-access',
+        refreshToken: 'test-refresh',
+        client: { id: '1', ime: 'Ana', prezime: 'Jovic', email: 'ana@gmail.com', permissions: [] },
+      },
+    })
+    vi.mocked(clientAuthApi.logout).mockRejectedValueOnce(new Error('redis unavailable'))
+
+    const store = useClientAuthStore()
+    await store.login('ana@gmail.com', 'password123')
+    store.logout()
+
+    expect(store.accessToken).toBeNull()
+    expect(store.refreshToken).toBeNull()
+    expect(store.client).toBeNull()
+    expect(sessionStorage.getItem('client_access_token')).toBeNull()
   })
 
   it('exposes permissions and checks client trading access', async () => {

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,8 +1,23 @@
 import api from './client'
+import axios from 'axios'
+
+const BASE = import.meta.env.VITE_API_BASE_URL || '/api/v1'
 
 export const authApi = {
   login: (email: string, password: string) =>
     api.post('/auth/login', { email, password }),
+
+  logout: (accessToken: string, refreshToken?: string | null) =>
+    axios.post(
+      `${BASE}/auth/logout`,
+      refreshToken ? { refreshToken } : {},
+      {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          'Content-Type': 'application/json',
+        },
+      }
+    ),
 
   activateAccount: (token: string, password: string, passwordConfirm: string) =>
     api.post('/auth/activate', { token, password, passwordConfirm }),

--- a/src/api/clientAuth.ts
+++ b/src/api/clientAuth.ts
@@ -1,7 +1,9 @@
 import axios from 'axios'
 
+const BASE = import.meta.env.VITE_API_BASE_URL || '/api/v1'
+
 const clientApiClient = axios.create({
-  baseURL: import.meta.env.VITE_API_BASE_URL || '/api/v1',
+  baseURL: BASE,
   headers: { 'Content-Type': 'application/json' },
 })
 
@@ -14,6 +16,18 @@ clientApiClient.interceptors.request.use((config) => {
 export const clientAuthApi = {
   login(email: string, password: string) {
     return clientApiClient.post('/auth/client/login', { email, password })
+  },
+  logout(accessToken: string, refreshToken?: string | null) {
+    return axios.post(
+      `${BASE}/auth/client/logout`,
+      refreshToken ? { refreshToken } : {},
+      {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          'Content-Type': 'application/json',
+        },
+      }
+    )
   },
   activateAccount(token: string, password: string, passwordConfirm: string) {
     return clientApiClient.post('/auth/client/activate', { token, password, passwordConfirm })

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -52,11 +52,24 @@ export const useAuthStore = defineStore('auth', () => {
     sessionStorage.setItem('employee', JSON.stringify(data.employee))
   }
 
-  function logout() {
+  function clearSession() {
     accessToken.value = null
     refreshToken.value = null
     employee.value = null
     sessionStorage.clear()
+  }
+
+  function logout() {
+    const tokenToRevoke = accessToken.value
+    const refreshToRevoke = refreshToken.value
+
+    clearSession()
+
+    if (tokenToRevoke) {
+      void authApi.logout(tokenToRevoke, refreshToRevoke).catch(() => {
+        // Local logout must not be blocked by temporary backend/Redis issues.
+      })
+    }
   }
 
   return { employee, isLoggedIn, permissions, hasPermission, isAdmin, login, logout }

--- a/src/stores/clientAuth.ts
+++ b/src/stores/clientAuth.ts
@@ -31,13 +31,26 @@ export const useClientAuthStore = defineStore('clientAuth', () => {
     sessionStorage.setItem('client', JSON.stringify(data.client))
   }
 
-  function logout() {
+  function clearSession() {
     accessToken.value = null
     refreshToken.value = null
     client.value = null
     sessionStorage.removeItem('client_access_token')
     sessionStorage.removeItem('client_refresh_token')
     sessionStorage.removeItem('client')
+  }
+
+  function logout() {
+    const tokenToRevoke = accessToken.value
+    const refreshToRevoke = refreshToken.value
+
+    clearSession()
+
+    if (tokenToRevoke) {
+      void clientAuthApi.logout(tokenToRevoke, refreshToRevoke).catch(() => {
+        // Local logout must not be blocked by temporary backend/Redis issues.
+      })
+    }
   }
 
   function hasPermission(permission: string) {


### PR DESCRIPTION
## Summary
- Calls backend logout endpoints from employee and client logout flows.
- Revokes access/refresh tokens using the new Redis-backed backend revocation support.
- Keeps logout UX safe by clearing local session immediately even if backend logout fails.
- Adds store tests for employee/client logout behavior.

## Testing
- `npm test -- --run`
- `npm run build`