### PR TITLE
chore(k8s): runtime backend-URL config + image CD

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,33 @@
+name: CD
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build-and-push:
+    name: Build & Push (frontend)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        run: |
+          # Publish under the org/owner the workflow runs in (raf-si-2025 on the
+          # shared upstream repo). GHCR namespaces must be lowercase.
+          OWNER="${{ github.repository_owner }}"
+          OWNER="${OWNER,,}"
+          TAG="ghcr.io/${OWNER}/exbanka-3-frontend:latest"
+          docker build -t "$TAG" .
+          docker push "$TAG"

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,7 @@ RUN npm run build
 FROM nginx:alpine
 COPY --from=builder /app/dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
 EXPOSE 80
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# Regenerate /config.js from env vars before nginx starts.
+# Lets the same built bundle target dev (no env vars set → defaults) and the
+# college K8s cluster (API_ORIGIN / USE_SLUGS set in the Pod spec).
+set -e
+
+API_ORIGIN="${API_ORIGIN:-}"
+USE_SLUGS="${USE_SLUGS:-false}"
+
+case "${USE_SLUGS}" in
+  true|TRUE|1|yes) USE_SLUGS_JS=true ;;
+  *) USE_SLUGS_JS=false ;;
+esac
+
+cat > /usr/share/nginx/html/config.js <<EOF
+window.__APP_CONFIG__ = {
+  apiOrigin: "${API_ORIGIN}",
+  useSlugs: ${USE_SLUGS_JS}
+};
+EOF
+
+exec nginx -g 'daemon off;'

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>exbanka-3-frontend</title>
+    <script src="/config.js"></script>
   </head>
   <body>
     <div id="app"></div>

--- a/public/config.js
+++ b/public/config.js
@@ -1,0 +1,9 @@
+// Default runtime config — same-origin, no per-service URL slug.
+// In dev and local docker-compose this file is served as-is.
+// In the cluster, the frontend container entrypoint regenerates this file
+// from env vars (API_ORIGIN, USE_SLUGS) before nginx starts, so the same
+// built bundle can target any environment without rebuilding.
+window.__APP_CONFIG__ = {
+  apiOrigin: "",
+  useSlugs: false
+};

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,7 +1,6 @@
 import api from './client'
 import axios from 'axios'
-
-const BASE = import.meta.env.VITE_API_BASE_URL || '/api/v1'
+import { resolveApiUrl } from '../runtimeConfig'
 
 export const authApi = {
   login: (email: string, password: string) =>
@@ -9,7 +8,7 @@ export const authApi = {
 
   logout: (accessToken: string, refreshToken?: string | null) =>
     axios.post(
-      `${BASE}/auth/logout`,
+      resolveApiUrl('/api/v1/auth/logout'),
       refreshToken ? { refreshToken } : {},
       {
         headers: {

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,13 +1,16 @@
 import axios from 'axios'
-
-const BASE = import.meta.env.VITE_API_BASE_URL || '/api/v1'
+import { resolveApiUrl } from '../runtimeConfig'
 
 const api = axios.create({
-  baseURL: BASE,
+  baseURL: '/api/v1',
   headers: { 'Content-Type': 'application/json' },
 })
 
 api.interceptors.request.use((config) => {
+  const path = (config.baseURL ?? '') + (config.url ?? '')
+  config.baseURL = ''
+  config.url = resolveApiUrl(path)
+
   const token = sessionStorage.getItem('access_token')
   if (token) config.headers.Authorization = `Bearer ${token}`
   return config
@@ -22,7 +25,7 @@ api.interceptors.response.use(
       const refresh = sessionStorage.getItem('refresh_token')
       if (refresh) {
         try {
-          const res = await axios.post(`${BASE}/auth/refresh`, { refreshToken: refresh })
+          const res = await axios.post(resolveApiUrl('/api/v1/auth/refresh'), { refreshToken: refresh })
           sessionStorage.setItem('access_token', res.data.accessToken)
           sessionStorage.setItem('refresh_token', res.data.refreshToken)
           original.headers.Authorization = `Bearer ${res.data.accessToken}`

--- a/src/api/clientAuth.ts
+++ b/src/api/clientAuth.ts
@@ -1,13 +1,16 @@
 import axios from 'axios'
-
-const BASE = import.meta.env.VITE_API_BASE_URL || '/api/v1'
+import { resolveApiUrl } from '../runtimeConfig'
 
 const clientApiClient = axios.create({
-  baseURL: BASE,
+  baseURL: '/api/v1',
   headers: { 'Content-Type': 'application/json' },
 })
 
 clientApiClient.interceptors.request.use((config) => {
+  const path = (config.baseURL ?? '') + (config.url ?? '')
+  config.baseURL = ''
+  config.url = resolveApiUrl(path)
+
   const token = sessionStorage.getItem('client_access_token')
   if (token) config.headers.Authorization = `Bearer ${token}`
   return config
@@ -19,7 +22,7 @@ export const clientAuthApi = {
   },
   logout(accessToken: string, refreshToken?: string | null) {
     return axios.post(
-      `${BASE}/auth/client/logout`,
+      resolveApiUrl('/api/v1/auth/client/logout'),
       refreshToken ? { refreshToken } : {},
       {
         headers: {

--- a/src/runtimeConfig.ts
+++ b/src/runtimeConfig.ts
@@ -1,0 +1,75 @@
+// Runtime config — read from window.__APP_CONFIG__ so the same built bundle
+// can be deployed to dev (same-origin nginx proxy) and to the college K8s
+// cluster (different domain, https, per-service URL slug) without rebuilding.
+//
+// The values are populated by /config.js, which is loaded synchronously from
+// index.html. In dev that file ships with empty defaults (public/config.js).
+// In the cluster, the container entrypoint regenerates /config.js from env
+// vars at startup (API_ORIGIN, USE_SLUGS).
+
+declare global {
+  interface Window {
+    __APP_CONFIG__?: {
+      apiOrigin?: string
+      useSlugs?: boolean | string
+    }
+  }
+}
+
+const cfg = (typeof window !== 'undefined' && window.__APP_CONFIG__) || {}
+
+export const apiOrigin: string = cfg.apiOrigin ?? ''
+export const useSlugs: boolean = cfg.useSlugs === true || cfg.useSlugs === 'true'
+
+// Resource-prefix → service-slug map. Source of truth is the Progress log in
+// `K8 deployment to college K8 cluster.md` (step 2). The order matters because
+// /api/v1/exchanges (plural) and /api/v1/exchange (singular) both belong to
+// exchange-service but the singular would partial-match the plural without the
+// (\/|$) anchor.
+const SLUG_MAP: Array<[RegExp, string]> = [
+  [/^\/api\/v1\/auth(\/|$)/, 'auth'],
+  [/^\/api\/v1\/permissions(\/|$)/, 'employee'],
+  [/^\/api\/v1\/employees(\/|$)/, 'employee'],
+  [/^\/api\/v1\/actuaries(\/|$)/, 'employee'],
+  [/^\/api\/v1\/clients(\/|$)/, 'client'],
+  [/^\/api\/v1\/firme(\/|$)/, 'account'],
+  [/^\/api\/v1\/sifre-delatnosti(\/|$)/, 'account'],
+  [/^\/api\/v1\/currencies(\/|$)/, 'account'],
+  [/^\/api\/v1\/accounts(\/|$)/, 'account'],
+  [/^\/api\/v1\/cards(\/|$)/, 'account'],
+  [/^\/api\/v1\/transfers(\/|$)/, 'transfer'],
+  [/^\/api\/v1\/payments(\/|$)/, 'payment'],
+  [/^\/api\/v1\/prenos(\/|$)/, 'payment'],
+  [/^\/api\/v1\/recipients(\/|$)/, 'payment'],
+  [/^\/api\/v1\/listings(\/|$)/, 'exchange'],
+  [/^\/api\/v1\/portfolio(\/|$)/, 'exchange'],
+  [/^\/api\/v1\/orders(\/|$)/, 'exchange'],
+  [/^\/api\/v1\/tax(\/|$)/, 'exchange'],
+  [/^\/api\/v1\/otc(\/|$)/, 'exchange'],
+  [/^\/api\/v1\/interbank-otc(\/|$)/, 'exchange'],
+  [/^\/api\/v1\/funds(\/|$)/, 'exchange'],
+  [/^\/api\/v1\/exchanges(\/|$)/, 'exchange'],
+  [/^\/api\/v1\/exchange(\/|$)/, 'exchange'],
+  [/^\/api\/v1\/loans(\/|$)/, 'loan'],
+]
+
+const FALLBACK_SLUG = 'core'
+
+function slugForPath(path: string): string {
+  for (const [re, slug] of SLUG_MAP) {
+    if (re.test(path)) return slug
+  }
+  return FALLBACK_SLUG
+}
+
+// Resolve an /api/v1/... path to the final URL based on runtime config.
+// - Dev (useSlugs=false, apiOrigin=""): returns path unchanged. Same-origin
+//   nginx routes by resource prefix exactly like today.
+// - Cluster (useSlugs=true, apiOrigin="https://<domain>"): returns
+//   `${apiOrigin}/<slug>${path}`. Ingress strips `/<slug>/` and forwards the
+//   remainder to the upstream service.
+export function resolveApiUrl(path: string): string {
+  if (!useSlugs) return apiOrigin + path
+  const slug = slugForPath(path)
+  return `${apiOrigin}/${slug}${path}`
+}


### PR DESCRIPTION
- Resolve API origin + slug routing at runtime from window.__APP_CONFIG__ (/config.js regenerated by entrypoint from API_ORIGIN/USE_SLUGS) so backend address/protocol change without a rebuild

- Add docker-entrypoint.sh, public/config.js, src/runtimeConfig.ts

- Add CD workflow to build and push the frontend image to the org registry