### PR TITLE
fix(nginx): remove duplicate /api/v1/audit-logs location

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -29,12 +29,6 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
     }
 
-    location /api/v1/audit-logs {
-        proxy_pass http://employee-service:8082;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-    }
-
     # Route client endpoints to the extracted client-service
     location /api/v1/clients {
         proxy_pass http://client-service:8083;


### PR DESCRIPTION
Two identical location blocks for /api/v1/audit-logs (a merge collision) made nginx fail to start with 'duplicate location', crash-looping the frontend pod. Keep the commented one, drop the dup.