### PR TITLE
fix(api): map watchlists, price-alerts, audit-logs to their service s…

### DIFF
--- a/src/runtimeConfig.ts
+++ b/src/runtimeConfig.ts
@@ -31,6 +31,7 @@ const SLUG_MAP: Array<[RegExp, string]> = [
   [/^\/api\/v1\/permissions(\/|$)/, 'employee'],
   [/^\/api\/v1\/employees(\/|$)/, 'employee'],
   [/^\/api\/v1\/actuaries(\/|$)/, 'employee'],
+  [/^\/api\/v1\/audit-logs(\/|$)/, 'employee'],
   [/^\/api\/v1\/clients(\/|$)/, 'client'],
   [/^\/api\/v1\/firme(\/|$)/, 'account'],
   [/^\/api\/v1\/sifre-delatnosti(\/|$)/, 'account'],
@@ -50,6 +51,8 @@ const SLUG_MAP: Array<[RegExp, string]> = [
   [/^\/api\/v1\/funds(\/|$)/, 'exchange'],
   [/^\/api\/v1\/exchanges(\/|$)/, 'exchange'],
   [/^\/api\/v1\/exchange(\/|$)/, 'exchange'],
+  [/^\/api\/v1\/watchlists(\/|$)/, 'exchange'],
+  [/^\/api\/v1\/price-alerts(\/|$)/, 'exchange'],
   [/^\/api\/v1\/loans(\/|$)/, 'loan'],
 ]
 


### PR DESCRIPTION
…lugs

These three resources had no SLUG_MAP entry, so in the cluster (useSlugs=true) they fell through to the 'core' fallback and were routed to /core/api -> the backend stub, returning 404. watchlists and price-alerts live in exchange-service; audit-logs in employee-service.