### PR TITLE
test(cypress): add sprint8 e2e for audit log, watchlist, price alerts

### DIFF
--- a/cypress/e2e/sprint8/audit-log.cy.js
+++ b/cypress/e2e/sprint8/audit-log.cy.js
@@ -1,0 +1,103 @@
+// Sprint 8 — Audit log privilegovanih akcija.
+//
+// Covers the supervisor/admin-only audit log:
+//   - AUDIT-BE: a privileged action (changing an employee's permissions)
+//     writes an EMPLOYEE_PERMISSIONS_CHANGED row with actor + resource.
+//   - AUDIT-FE: supervisor opens /audit-logs and sees the row; action and
+//     actor-id filters narrow the result; "Poništi" restores it.
+//   - AUDIT-FE: a non-supervisor employee is bounced off the route.
+//
+// The audited action is produced by the real admin API (createSupervisor /
+// createAgent both PUT /employees/:id/permissions), so the row under test is
+// a genuine side-effect rather than seeded data.
+
+import { adminLogin } from '../helpers/banking'
+import { loginEmployeeUi } from '../helpers/employee'
+import { createSupervisor, createAgent, DEFAULT_EMPLOYEE_PASSWORD } from '../helpers/actuary'
+
+const PERMS_CHANGED_LABEL = 'Dozvole zaposlenog promenjene'
+
+function fetchAdminId() {
+  return cy
+    .task('dbExec', {
+      sql: 'SELECT id FROM employees WHERE email = $1 LIMIT 1',
+      params: [Cypress.env('adminEmail')],
+    })
+    .then(({ rows }) => {
+      expect(rows[0], 'admin employee row').to.exist
+      return Number(rows[0].id)
+    })
+}
+
+describe('Sprint 8 — Audit log', () => {
+  it('Supervizor vidi audit zapis promene dozvola i moze da filtrira', function () {
+    const ctx = {}
+
+    adminLogin()
+      .then((token) => {
+        ctx.adminToken = token
+        return fetchAdminId()
+      })
+      .then((adminId) => {
+        ctx.adminId = adminId
+        // Activating the supervisor PUTs its permissions -> audited action.
+        return createSupervisor(ctx.adminToken, 's8-audit-sup')
+      })
+      .then((sup) => {
+        ctx.sup = sup
+
+        loginEmployeeUi(sup.email, DEFAULT_EMPLOYEE_PASSWORD)
+        cy.visit('/audit-logs')
+
+        cy.contains('h1', 'Audit log').should('be.visible')
+        cy.contains('.summary-bar', 'pronađeno').should('be.visible')
+
+        // The supervisor's own permission-grant is in the log: resource
+        // "employee #<id>" with the perms-changed action badge.
+        cy.contains('.audit-table tr', `#${sup.id}`).within(() => {
+          cy.contains('.action-badge', PERMS_CHANGED_LABEL).should('be.visible')
+          cy.contains('.res-type', 'employee').should('be.visible')
+        })
+
+        // Filter by action -> every visible row is a permissions change.
+        cy.get('.filter-select').select(PERMS_CHANGED_LABEL)
+        cy.contains('button', 'Filtriraj').click()
+        cy.get('.action-badge').should('have.length.greaterThan', 0)
+        cy.get('.action-badge').each(($b) => {
+          expect($b.text().trim()).to.eq(PERMS_CHANGED_LABEL)
+        })
+
+        // Filter by the admin actor id -> the row is still there.
+        cy.get('input[placeholder="npr. 42"]').clear().type(String(ctx.adminId))
+        cy.contains('button', 'Filtriraj').click()
+        cy.contains('.audit-table tr', `#${sup.id}`).should('be.visible')
+
+        // A non-existent actor id -> empty result.
+        cy.get('input[placeholder="npr. 42"]').clear().type('99999999')
+        cy.contains('button', 'Filtriraj').click()
+        cy.contains('Nema zapisa za odabrane filtere.').should('be.visible')
+
+        // Reset filters -> rows return.
+        cy.contains('button', 'Poništi').click()
+        cy.contains('.audit-table tr', `#${sup.id}`).should('be.visible')
+      })
+  })
+
+  it('Zaposleni bez supervisor dozvole ne moze da otvori audit log', function () {
+    const ctx = {}
+
+    adminLogin()
+      .then((token) => {
+        ctx.adminToken = token
+        return createAgent(token, 's8-audit-agent')
+      })
+      .then((agent) => {
+        loginEmployeeUi(agent.email, DEFAULT_EMPLOYEE_PASSWORD)
+        cy.visit('/audit-logs')
+
+        // Route guard (employeeSupervisorOnly) bounces agents to /clients.
+        cy.url().should('match', /\/clients$/)
+        cy.contains('h1', 'Audit log').should('not.exist')
+      })
+  })
+})

--- a/cypress/e2e/sprint8/price-alerts.cy.js
+++ b/cypress/e2e/sprint8/price-alerts.cy.js
@@ -1,0 +1,130 @@
+// Sprint 8 — Cenovni alarmi (price alerts).
+//
+// Covers the client-facing price-alert feature end-to-end through the UI:
+//   - ALERT-FE: set an ABOVE / BELOW alarm from the security-details page.
+//   - ALERT-FE: the "Cenovni alarmi" page lists active alarms with the right
+//     condition badge, threshold, and notification email (captured from JWT).
+//   - ALERT-FE/BE: removing an alarm deactivates it and empties the list.
+//
+// A trading-enabled client is provisioned via the admin API; everything else
+// is driven through the browser. DB assertions confirm persistence.
+
+import {
+  adminLogin,
+  createClient,
+  activateClient,
+  loginClientUi,
+} from '../helpers/banking'
+import { grantClientTrading } from '../helpers/otc'
+import { lookupListingId } from '../helpers/orders'
+
+const TICKER = 'AAPL'
+const ABOVE_THRESHOLD = 999.99
+const BELOW_THRESHOLD = 50
+
+function fetchAlerts(clientId) {
+  return cy
+    .task('dbExec', {
+      sql: `SELECT ticker, condition, threshold::float AS threshold,
+                   notification_email, is_active
+            FROM price_alerts
+            WHERE user_id = $1 AND user_type = 'client'
+            ORDER BY id`,
+      params: [Number(clientId)],
+    })
+    .then(({ rows }) => rows)
+}
+
+function setAlarm(condition, threshold) {
+  cy.visit(`/client/securities/${TICKER}`)
+  cy.contains('.ticker-pill', TICKER).should('be.visible')
+  cy.get('.alert-form select').select(condition)
+  cy.get('.alert-form input[type="number"]').clear().type(String(threshold))
+  cy.contains('.alert-form button', 'Postavi alarm').click()
+  cy.contains('.alert-msg-ok', 'Alarm uspešno postavljen!').should('be.visible')
+}
+
+describe('Sprint 8 — Cenovni alarmi', () => {
+  beforeEach(function () {
+    this.ctx = {}
+    adminLogin()
+      .then((token) => {
+        this.ctx.adminToken = token
+        return lookupListingId(TICKER)
+      })
+      .then(() => createClient(this.ctx.adminToken, 's8-alerts'))
+      .then((client) => {
+        this.ctx.client = client
+        return activateClient(client.setupToken)
+      })
+      .then(() => grantClientTrading(this.ctx.adminToken, this.ctx.client.id))
+      .then(() => {
+        loginClientUi(this.ctx.client.email)
+      })
+  })
+
+  it('Klijent postavlja ABOVE alarm i vidi ga na stranici alarma', function () {
+    const ctx = this.ctx
+
+    setAlarm('ABOVE', ABOVE_THRESHOLD)
+
+    cy.visit('/client/price-alerts')
+    cy.contains('h1', 'Cenovni alarmi').should('be.visible')
+    cy.contains('.summary-bar', '1 aktivan alarm').should('be.visible')
+
+    cy.contains('.alerts-table tr', TICKER).within(() => {
+      cy.get('.col-ticker').should('contain', TICKER)
+      cy.contains('.cond-badge', 'Iznad').should('be.visible')
+      cy.get('.col-threshold').should('contain', ABOVE_THRESHOLD.toFixed(2))
+      cy.get('.col-email').should('contain', ctx.client.email)
+    })
+
+    // Persisted with the email captured from the JWT.
+    cy.then(() => fetchAlerts(ctx.client.id)).then((alerts) => {
+      expect(alerts).to.have.length(1)
+      expect(alerts[0].condition).to.eq('ABOVE')
+      expect(Number(alerts[0].threshold)).to.be.closeTo(ABOVE_THRESHOLD, 0.001)
+      expect(alerts[0].notification_email).to.eq(ctx.client.email)
+      expect(alerts[0].is_active).to.eq(true)
+    })
+  })
+
+  it('ABOVE i BELOW alarmi prikazuju ispravne bedzeve; uklanjanje prazni listu', function () {
+    const ctx = this.ctx
+
+    setAlarm('ABOVE', ABOVE_THRESHOLD)
+    setAlarm('BELOW', BELOW_THRESHOLD)
+
+    cy.visit('/client/price-alerts')
+    cy.contains('.summary-bar', '2 aktivnih alarma').should('be.visible')
+    cy.contains('.cond-badge', 'Iznad').should('be.visible')
+    cy.contains('.cond-badge', 'Ispod').should('be.visible')
+
+    // Remove the first alarm row.
+    cy.get('.alerts-table tbody tr').should('have.length', 2)
+    cy.get('.alerts-table tbody tr').first().within(() => {
+      cy.contains('button', 'Ukloni').click()
+    })
+    cy.get('.alerts-table tbody tr').should('have.length', 1)
+
+    // Remove the last one -> empty state.
+    cy.get('.alerts-table tbody tr').first().within(() => {
+      cy.contains('button', 'Ukloni').click()
+    })
+    cy.contains('Nemate aktivnih alarma').should('be.visible')
+
+    // DB: both alarms deactivated (the list endpoint only returns active ones).
+    cy.then(() => fetchAlerts(ctx.client.id)).then((alerts) => {
+      const active = alerts.filter((a) => a.is_active === true)
+      expect(active, 'no active alarms remain').to.have.length(0)
+    })
+  })
+
+  it('Prag mora biti pozitivan', function () {
+    cy.visit(`/client/securities/${TICKER}`)
+    cy.contains('.ticker-pill', TICKER).should('be.visible')
+    // Leave threshold empty and submit -> client-side validation error.
+    cy.contains('.alert-form button', 'Postavi alarm').click()
+    cy.contains('.alert-msg-err', 'Unesi pozitivan prag cene.').should('be.visible')
+  })
+})

--- a/cypress/e2e/sprint8/watchlist.cy.js
+++ b/cypress/e2e/sprint8/watchlist.cy.js
@@ -1,0 +1,162 @@
+// Sprint 8 — Watchliste hartija od vrednosti.
+//
+// Covers the client-facing watchlist feature end-to-end through the real UI:
+//   - WL-FE: create a named watchlist, add a ticker, see it in the table.
+//   - WL-BE: duplicate ticker -> 409, unknown ticker -> 400 (surfaced as
+//     inline errors), remove a ticker, delete a whole list.
+//   - Cross-page: add a security to a list from the security-details page.
+//
+// A trading-enabled client is provisioned via the admin API; the watchlist
+// behaviour itself is driven through the browser so the recording shows the
+// real client portal. DB assertions confirm the persisted side-effects.
+
+import {
+  adminLogin,
+  createClient,
+  activateClient,
+  loginClientUi,
+} from '../helpers/banking'
+import { grantClientTrading } from '../helpers/otc'
+import { lookupListingId } from '../helpers/orders'
+
+const TICKER = 'AAPL'
+
+function fetchWatchlistTickers(clientId) {
+  return cy
+    .task('dbExec', {
+      sql: `SELECT wi.ticker AS ticker
+            FROM watchlist_items wi
+            JOIN watchlists w ON w.id = wi.watchlist_id
+            WHERE w.user_id = $1 AND w.user_type = 'client'`,
+      params: [Number(clientId)],
+    })
+    .then(({ rows }) => rows.map((r) => r.ticker))
+}
+
+describe('Sprint 8 — Watchliste hartija', () => {
+  beforeEach(function () {
+    this.ctx = {}
+    adminLogin()
+      .then((token) => {
+        this.ctx.adminToken = token
+        // Ensure the ticker we rely on really exists on the seeded exchange.
+        return lookupListingId(TICKER)
+      })
+      .then((assetId) => {
+        this.ctx.assetId = assetId
+        return createClient(this.ctx.adminToken, 's8-watchlist')
+      })
+      .then((client) => {
+        this.ctx.client = client
+        return activateClient(client.setupToken)
+      })
+      .then(() => grantClientTrading(this.ctx.adminToken, this.ctx.client.id))
+      .then(() => {
+        loginClientUi(this.ctx.client.email)
+      })
+  })
+
+  it('Klijent kreira listu, dodaje hartiju i vidi je u tabeli', function () {
+    const ctx = this.ctx
+
+    cy.visit('/client/watchlist')
+    cy.contains('h1', 'Moje watchliste').should('be.visible')
+
+    // Create a watchlist.
+    cy.contains('button', '+ Nova lista').click()
+    cy.get('input[placeholder="Naziv liste"]').type('Tehnologija')
+    cy.contains('button', 'Kreiraj').click()
+
+    // The new list shows up as an active tab.
+    cy.contains('.wl-tab', 'Tehnologija').should('have.class', 'active')
+
+    // Add a ticker.
+    cy.get('input[placeholder="Ticker (npr. AAPL)"]').type(TICKER)
+    cy.contains('button', 'Dodaj').click()
+
+    // Row appears in the items table.
+    cy.contains('.items-table tr', TICKER).within(() => {
+      cy.get('.ticker-cell').should('contain', TICKER)
+      cy.contains('button', 'Kupi').should('be.visible')
+      cy.contains('button', 'Ukloni').should('be.visible')
+    })
+
+    // Persisted in the DB.
+    cy.then(() => fetchWatchlistTickers(ctx.client.id)).then((tickers) => {
+      expect(tickers, 'ticker persisted on the watchlist').to.include(TICKER)
+    })
+  })
+
+  it('Duplikat i nepostojeci ticker daju greske; uklanjanje hartije prazni listu', function () {
+    cy.visit('/client/watchlist')
+
+    cy.contains('button', '+ Nova lista').click()
+    cy.get('input[placeholder="Naziv liste"]').type('Lista A')
+    cy.contains('button', 'Kreiraj').click()
+    cy.contains('.wl-tab', 'Lista A').should('have.class', 'active')
+
+    const addTicker = (value) => {
+      cy.get('input[placeholder="Ticker (npr. AAPL)"]').clear().type(value)
+      cy.contains('button', 'Dodaj').click()
+    }
+
+    // First add succeeds.
+    addTicker(TICKER)
+    cy.contains('.items-table tr', TICKER).should('be.visible')
+
+    // Duplicate -> inline 409 error.
+    addTicker(TICKER)
+    cy.contains('.error-msg', `${TICKER} je već na ovoj listi.`).should('be.visible')
+
+    // Unknown ticker -> inline 400 error.
+    addTicker('ZZINVALID')
+    cy.contains('.error-msg', 'ne postoji na berzi').should('be.visible')
+
+    // Remove the ticker -> list becomes empty.
+    cy.contains('.items-table tr', TICKER).within(() => {
+      cy.contains('button', 'Ukloni').click()
+    })
+    cy.contains('Lista je prazna').should('be.visible')
+  })
+
+  it('Brisanje liste uklanja je iz tabova', function () {
+    cy.visit('/client/watchlist')
+
+    cy.contains('button', '+ Nova lista').click()
+    cy.get('input[placeholder="Naziv liste"]').type('Za brisanje')
+    cy.contains('button', 'Kreiraj').click()
+    cy.contains('.wl-tab', 'Za brisanje').should('be.visible')
+
+    // confirm() defaults to accepted in Cypress.
+    cy.contains('button', 'Obriši listu').click()
+
+    cy.contains('.wl-tab', 'Za brisanje').should('not.exist')
+  })
+
+  it('Hartija se moze dodati na listu sa stranice detalja', function () {
+    const ctx = this.ctx
+
+    // Create an (empty) target list first.
+    cy.visit('/client/watchlist')
+    cy.contains('button', '+ Nova lista').click()
+    cy.get('input[placeholder="Naziv liste"]').type('Iz detalja')
+    cy.contains('button', 'Kreiraj').click()
+    cy.contains('.wl-tab', 'Iz detalja').should('be.visible')
+
+    // Add from the security-details page via the "Na watchlist" menu.
+    cy.visit(`/client/securities/${TICKER}`)
+    cy.contains('.ticker-pill', TICKER).should('be.visible')
+    cy.contains('button', 'Na watchlist').click()
+    cy.contains('.wl-menu-item', 'Iz detalja').click()
+    cy.contains('.wl-add-msg', 'Dodato na "Iz detalja"').should('be.visible')
+
+    // Verify it shows on the watchlist page and is persisted.
+    cy.visit('/client/watchlist')
+    cy.contains('.wl-tab', 'Iz detalja').click()
+    cy.contains('.items-table tr', TICKER).should('be.visible')
+
+    cy.then(() => fetchWatchlistTickers(ctx.client.id)).then((tickers) => {
+      expect(tickers).to.include(TICKER)
+    })
+  })
+})

--- a/cypress/support/db-cleanup.js
+++ b/cypress/support/db-cleanup.js
@@ -14,6 +14,9 @@ DELETE FROM otc_contracts WHERE buyer_type = 'client' AND buyer_id IN (SELECT id
 DELETE FROM otc_offers WHERE seller_type = 'client' AND seller_id IN (SELECT id FROM clients WHERE email LIKE 'cypress.%@example.com');
 DELETE FROM otc_offers WHERE buyer_type = 'client' AND buyer_id IN (SELECT id FROM clients WHERE email LIKE 'cypress.%@example.com');
 DELETE FROM portfolio_holdings WHERE user_type = 'client' AND user_id IN (SELECT id FROM clients WHERE email LIKE 'cypress.%@example.com');
+DELETE FROM watchlist_items WHERE watchlist_id IN (SELECT id FROM watchlists WHERE user_type = 'client' AND user_id IN (SELECT id FROM clients WHERE email LIKE 'cypress.%@example.com'));
+DELETE FROM watchlists WHERE user_type = 'client' AND user_id IN (SELECT id FROM clients WHERE email LIKE 'cypress.%@example.com');
+DELETE FROM price_alerts WHERE user_type = 'client' AND user_id IN (SELECT id FROM clients WHERE email LIKE 'cypress.%@example.com');
 DELETE FROM loan_installments WHERE loan_id IN (SELECT id FROM loans WHERE client_id IN (SELECT id FROM clients WHERE email LIKE 'cypress.%@example.com'));
 DELETE FROM transfers WHERE racun_posiljaoca_id IN (SELECT id FROM accounts WHERE client_id IN (SELECT id FROM clients WHERE email LIKE 'cypress.%@example.com')) OR racun_primaoca_id IN (SELECT id FROM accounts WHERE client_id IN (SELECT id FROM clients WHERE email LIKE 'cypress.%@example.com'));
 DELETE FROM payments WHERE racun_posiljaoca_id IN (SELECT id FROM accounts WHERE client_id IN (SELECT id FROM clients WHERE email LIKE 'cypress.%@example.com'));
@@ -25,6 +28,11 @@ DELETE FROM accounts WHERE client_id IN (SELECT id FROM clients WHERE email LIKE
 DELETE FROM client_permissions WHERE client_id IN (SELECT id FROM clients WHERE email LIKE 'cypress.%@example.com');
 DELETE FROM firmas WHERE vlasnik_id IN (SELECT id FROM clients WHERE email LIKE 'cypress.%@example.com');
 DELETE FROM clients WHERE email LIKE 'cypress.%@example.com';
+DELETE FROM watchlist_items WHERE watchlist_id IN (SELECT id FROM watchlists WHERE user_type = 'employee' AND user_id IN (SELECT id FROM employees WHERE email LIKE 'cypress.employee.%@bank.com'));
+DELETE FROM watchlists WHERE user_type = 'employee' AND user_id IN (SELECT id FROM employees WHERE email LIKE 'cypress.employee.%@bank.com');
+DELETE FROM price_alerts WHERE user_type = 'employee' AND user_id IN (SELECT id FROM employees WHERE email LIKE 'cypress.employee.%@bank.com');
+DELETE FROM audit_logs WHERE resource_type = 'employee' AND resource_id IN (SELECT id FROM employees WHERE email LIKE 'cypress.employee.%@bank.com');
+DELETE FROM audit_logs WHERE actor_id IN (SELECT id FROM employees WHERE email LIKE 'cypress.employee.%@bank.com');
 DELETE FROM actuary_profiles WHERE employee_id IN (SELECT id FROM employees WHERE email LIKE 'cypress.employee.%@bank.com');
 DELETE FROM employee_permissions WHERE employee_id IN (SELECT id FROM employees WHERE email LIKE 'cypress.employee.%@bank.com');
 DELETE FROM tokens WHERE employee_id IN (SELECT id FROM employees WHERE email LIKE 'cypress.employee.%@bank.com');


### PR DESCRIPTION
Cover the three new features through the real client/employee portals:
- watchlist: create list, add/remove tickers, duplicate (409) and unknown ticker (400) errors, delete list, add-from-security-details flow
- price alerts: set ABOVE/BELOW alarm from security details, list/remove on the alerts page, positive-threshold validation
- audit log: supervisor views a real EMPLOYEE_PERMISSIONS_CHANGED entry, action + actor-id filters, and the non-supervisor route guard

Extend db-cleanup to purge cypress-owned watchlists, watchlist_items, price_alerts and audit_logs so repeated runs stay isolated.