### PR TITLE
feat: notification bell + slug routing for notifications

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -169,6 +169,13 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
     }
 
+    # Route notification endpoints to notification-service
+    location /api/v1/notifications {
+        proxy_pass http://notification-service:8090;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+
     # Route audit-log endpoints to employee-service
     location /api/v1/audit-logs {
         proxy_pass http://employee-service:8082;

--- a/src/api/notification.ts
+++ b/src/api/notification.ts
@@ -1,0 +1,40 @@
+import employeeApi from './client'
+import clientApi from './clientAuth'
+
+export interface AppNotification {
+  id: number
+  user_id: number
+  user_type: string
+  type: string
+  title: string
+  body: string
+  link: string
+  is_read: boolean
+  created_at: string
+}
+
+// A session is either employee (sessionStorage.access_token) or client
+// (sessionStorage.client_access_token) — never both. Pick the matching axios
+// instance so the same store serves both portals.
+function pickApi() {
+  return sessionStorage.getItem('access_token') ? employeeApi : clientApi
+}
+
+export const notificationApi = {
+  list: (unreadOnly = false) =>
+    pickApi().get<AppNotification[]>('/notifications', {
+      params: unreadOnly ? { unread: 'true' } : undefined,
+    }),
+
+  unreadCount: () =>
+    pickApi().get<{ unread: number }>('/notifications/unread-count'),
+
+  markRead: (id: number) =>
+    pickApi().post(`/notifications/${id}/read`),
+
+  markAllRead: () =>
+    pickApi().post('/notifications/read-all'),
+
+  remove: (id: number) =>
+    pickApi().delete(`/notifications/${id}`),
+}

--- a/src/components/NotificationBell.vue
+++ b/src/components/NotificationBell.vue
@@ -1,0 +1,139 @@
+<script setup lang="ts">
+import { onMounted, onBeforeUnmount, ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { useNotificationStore } from '../stores/notification'
+import type { AppNotification } from '../api/notification'
+
+const props = withDefaults(defineProps<{ basePath?: string }>(), { basePath: '/client' })
+
+const store = useNotificationStore()
+const router = useRouter()
+const open = ref(false)
+const rootEl = ref<HTMLElement | null>(null)
+
+function toggle() {
+  open.value = !open.value
+  if (open.value) store.fetchAll()
+}
+
+function onClickOutside(e: MouseEvent) {
+  if (rootEl.value && !rootEl.value.contains(e.target as Node)) {
+    open.value = false
+  }
+}
+
+async function onClickNotification(n: AppNotification) {
+  if (!n.is_read) await store.markRead(n.id)
+  if (n.link) {
+    open.value = false
+    router.push(`${props.basePath}${n.link}`).catch(() => {})
+  }
+}
+
+function formatTime(iso: string): string {
+  const d = new Date(iso)
+  if (isNaN(d.getTime())) return ''
+  return d.toLocaleString('sr-RS', {
+    day: '2-digit', month: '2-digit', hour: '2-digit', minute: '2-digit',
+  })
+}
+
+onMounted(() => {
+  store.startPolling()
+  document.addEventListener('click', onClickOutside)
+})
+
+onBeforeUnmount(() => {
+  document.removeEventListener('click', onClickOutside)
+})
+</script>
+
+<template>
+  <div ref="rootEl" class="notif-bell">
+    <button class="notif-trigger" :class="{ active: open }" @click="toggle" aria-label="Obaveštenja">
+      <span class="notif-icon">🔔</span>
+      <span v-if="store.unread > 0" class="notif-badge">{{ store.unread > 99 ? '99+' : store.unread }}</span>
+    </button>
+
+    <div v-if="open" class="notif-dropdown">
+      <div class="notif-header">
+        <span>Obaveštenja</span>
+        <button v-if="store.unread > 0" class="notif-mark-all" @click="store.markAllRead()">
+          Označi sve kao pročitano
+        </button>
+      </div>
+
+      <div class="notif-list">
+        <div v-if="store.loading" class="notif-empty">Učitavanje…</div>
+        <div v-else-if="store.items.length === 0" class="notif-empty">Nema obaveštenja.</div>
+        <button
+          v-for="n in store.items"
+          :key="n.id"
+          class="notif-item"
+          :class="{ unread: !n.is_read }"
+          @click="onClickNotification(n)"
+        >
+          <div class="notif-item-top">
+            <span class="notif-item-title">{{ n.title }}</span>
+            <span class="notif-item-time">{{ formatTime(n.created_at) }}</span>
+          </div>
+          <div class="notif-item-body">{{ n.body }}</div>
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.notif-bell { position: relative; }
+
+.notif-trigger {
+  position: relative; width: 40px; height: 40px; border-radius: 10px;
+  background: #fff; border: 1px solid #e2e8f0; cursor: pointer;
+  display: flex; align-items: center; justify-content: center;
+  font-size: 18px; transition: all 0.15s ease;
+}
+.notif-trigger:hover, .notif-trigger.active { background: #f1f5f9; border-color: #cbd5e1; }
+
+.notif-badge {
+  position: absolute; top: -6px; right: -6px;
+  min-width: 18px; height: 18px; padding: 0 5px; border-radius: 9px;
+  background: #ef4444; color: #fff; font-size: 11px; font-weight: 700;
+  display: flex; align-items: center; justify-content: center; line-height: 1;
+}
+
+.notif-dropdown {
+  position: absolute; top: 48px; right: 0; width: 360px; max-height: 460px;
+  background: #fff; border: 1px solid #e2e8f0; border-radius: 12px;
+  box-shadow: 0 12px 32px rgba(15,23,42,0.16); z-index: 100;
+  display: flex; flex-direction: column; overflow: hidden;
+}
+
+.notif-header {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 14px 16px; border-bottom: 1px solid #f1f5f9;
+  font-size: 14px; font-weight: 700; color: #0f172a;
+}
+.notif-mark-all {
+  background: none; border: none; cursor: pointer;
+  color: #3b82f6; font-size: 12px; font-weight: 600;
+}
+.notif-mark-all:hover { text-decoration: underline; }
+
+.notif-list { overflow-y: auto; }
+.notif-empty { padding: 28px 16px; text-align: center; color: #94a3b8; font-size: 13px; }
+
+.notif-item {
+  width: 100%; text-align: left; cursor: pointer;
+  padding: 12px 16px; border: none; background: #fff;
+  border-bottom: 1px solid #f1f5f9; transition: background 0.12s;
+}
+.notif-item:hover { background: #f8fafc; }
+.notif-item.unread { background: #eff6ff; }
+.notif-item.unread:hover { background: #dbeafe; }
+
+.notif-item-top { display: flex; justify-content: space-between; gap: 8px; margin-bottom: 3px; }
+.notif-item-title { font-size: 13px; font-weight: 600; color: #0f172a; }
+.notif-item-time { font-size: 11px; color: #94a3b8; white-space: nowrap; }
+.notif-item-body { font-size: 12px; color: #475569; line-height: 1.4; }
+</style>

--- a/src/runtimeConfig.ts
+++ b/src/runtimeConfig.ts
@@ -54,6 +54,7 @@ const SLUG_MAP: Array<[RegExp, string]> = [
   [/^\/api\/v1\/watchlists(\/|$)/, 'exchange'],
   [/^\/api\/v1\/price-alerts(\/|$)/, 'exchange'],
   [/^\/api\/v1\/loans(\/|$)/, 'loan'],
+  [/^\/api\/v1\/notifications(\/|$)/, 'notification'],
 ]
 
 const FALLBACK_SLUG = 'core'

--- a/src/stores/notification.ts
+++ b/src/stores/notification.ts
@@ -1,0 +1,103 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import { notificationApi, type AppNotification } from '../api/notification'
+
+const POLL_INTERVAL_MS = 30_000
+
+export const useNotificationStore = defineStore('notification', () => {
+  const items = ref<AppNotification[]>([])
+  const unread = ref(0)
+  const loading = ref(false)
+  const error = ref('')
+
+  let pollTimer: ReturnType<typeof setInterval> | null = null
+
+  async function fetchUnreadCount() {
+    try {
+      const res = await notificationApi.unreadCount()
+      unread.value = res.data?.unread ?? 0
+    } catch {
+      // silent — badge just keeps its last value
+    }
+  }
+
+  async function fetchAll() {
+    loading.value = true
+    error.value = ''
+    try {
+      const res = await notificationApi.list()
+      items.value = res.data ?? []
+      unread.value = items.value.filter((n) => !n.is_read).length
+    } catch (e: any) {
+      error.value = e?.response?.data?.message ?? 'Greška pri učitavanju obaveštenja.'
+      items.value = []
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function markRead(id: number) {
+    try {
+      await notificationApi.markRead(id)
+      const n = items.value.find((i) => i.id === id)
+      if (n && !n.is_read) {
+        n.is_read = true
+        unread.value = Math.max(0, unread.value - 1)
+      }
+    } catch {
+      // ignore — next poll reconciles
+    }
+  }
+
+  async function markAllRead() {
+    try {
+      await notificationApi.markAllRead()
+      items.value.forEach((n) => (n.is_read = true))
+      unread.value = 0
+    } catch {
+      // ignore
+    }
+  }
+
+  async function remove(id: number) {
+    try {
+      await notificationApi.remove(id)
+      const n = items.value.find((i) => i.id === id)
+      if (n && !n.is_read) unread.value = Math.max(0, unread.value - 1)
+      items.value = items.value.filter((i) => i.id !== id)
+    } catch {
+      // ignore
+    }
+  }
+
+  // startPolling kicks off a lightweight unread-count poll. Safe to call more
+  // than once — it never stacks timers.
+  function startPolling() {
+    fetchUnreadCount()
+    if (pollTimer) return
+    pollTimer = setInterval(fetchUnreadCount, POLL_INTERVAL_MS)
+  }
+
+  function stopPolling() {
+    if (pollTimer) {
+      clearInterval(pollTimer)
+      pollTimer = null
+    }
+    items.value = []
+    unread.value = 0
+  }
+
+  return {
+    items,
+    unread,
+    loading,
+    error,
+    fetchUnreadCount,
+    fetchAll,
+    markRead,
+    markAllRead,
+    remove,
+    startPolling,
+    stopPolling,
+  }
+})

--- a/src/views/EmployeeLayout.vue
+++ b/src/views/EmployeeLayout.vue
@@ -3,6 +3,7 @@ import { computed } from 'vue'
 import { useRouter, RouterLink, useRoute } from 'vue-router'
 import { useAuthStore } from '../stores/auth'
 import { usePermissions } from '../composables/usePermissions'
+import NotificationBell from '../components/NotificationBell.vue'
 
 const router = useRouter()
 const route = useRoute()
@@ -84,6 +85,9 @@ function isActive(to: string) {
     </aside>
 
     <main class="emp-main">
+      <div class="emp-topbar">
+        <NotificationBell base-path="" />
+      </div>
       <RouterView />
     </main>
   </div>
@@ -256,5 +260,14 @@ function isActive(to: string) {
   margin-left: 260px;
   background: #f8fafc;
   min-height: 100vh;
+}
+
+.emp-topbar {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  padding: 12px 24px;
+  background: #fff;
+  border-bottom: 1px solid #e2e8f0;
 }
 </style>

--- a/src/views/client/ClientLayout.vue
+++ b/src/views/client/ClientLayout.vue
@@ -3,6 +3,7 @@ import { computed, ref } from 'vue'
 import { useRouter, RouterLink, useRoute } from 'vue-router'
 import { useClientAuthStore } from '../../stores/clientAuth'
 import WatchlistTickerStrip from '../../components/WatchlistTickerStrip.vue'
+import NotificationBell from '../../components/NotificationBell.vue'
 
 const router = useRouter()
 const route = useRoute()
@@ -128,6 +129,9 @@ function isPaymentSection() {
     </aside>
 
     <main class="client-main">
+      <div class="client-topbar">
+        <NotificationBell />
+      </div>
       <WatchlistTickerStrip v-if="canAccessMarket" />
       <RouterView />
     </main>
@@ -200,4 +204,8 @@ function isPaymentSection() {
 }
 .sidebar-logout:hover { background: rgba(239,68,68,0.15); color: #fca5a5; border-color: rgba(239,68,68,0.2); }
 .client-main { flex: 1; margin-left: 260px; background: #f8fafc; min-height: 100vh; }
+.client-topbar {
+  display: flex; align-items: center; justify-content: flex-end;
+  padding: 12px 24px; background: #fff; border-bottom: 1px solid #e2e8f0;
+}
 </style>


### PR DESCRIPTION
Add the in-app notification bell (NotificationBell.vue), Pinia store with 30s unread-count polling, and api/notification.ts (picks employee vs client axios instance by session token). Mount the bell in both ClientLayout and EmployeeLayout. Route /api/v1/notifications to the `notification` slug (runtimeConfig) and proxy it in nginx.conf.