### PR TITLE
feat(funds): dividend policy/history + statistics & benchmark UI

### DIFF
--- a/src/api/fund.ts
+++ b/src/api/fund.ts
@@ -5,6 +5,17 @@
 import employeeApi from './client'
 import clientApi from './clientAuth'
 
+export type FundDividendPolicy = 'reinvest' | 'payout'
+
+export interface FundStatistics {
+  available: boolean
+  monthsOfData: number
+  annualizedReturn: number
+  volatility: number
+  rewardToVariability: number
+  maxDrawdown: number
+}
+
 export interface FundSummary {
   id: number
   naziv: string
@@ -13,6 +24,7 @@ export interface FundSummary {
   managerId: number
   accountId: number
   datumKreiranja: string
+  dividendPolicy: FundDividendPolicy
   fundValueRSD: number
   liquidCashRSD: number
   holdingsValueRSD: number
@@ -20,6 +32,26 @@ export interface FundSummary {
   profitRSD: number
   participantsCount: number
   withdrawalCommRate: number
+  statistics?: FundStatistics
+}
+
+export interface FundDividend {
+  id: number
+  assetId: number
+  ticker: string
+  period: string
+  quantity: number
+  grossRSD: number
+  policy: FundDividendPolicy
+  reinvestedShares: number
+  reinvestedRSD: number
+  distributedRSD: number
+  paidAt: string
+}
+
+export interface BenchmarkPoint {
+  date: string
+  indexValue: number
 }
 
 export interface FundHolding {
@@ -94,6 +126,21 @@ function fundApiFor(axiosInstance: typeof employeeApi) {
       axiosInstance.get<{ performance: FundPerformancePoint[]; count: number; granularity: string }>(
         `/funds/${id}/performance`,
         { params: { granularity } },
+      ),
+    statistics: (id: number) =>
+      axiosInstance.get<{ statistics: FundStatistics }>(`/funds/${id}/statistics`),
+    dividends: (id: number) =>
+      axiosInstance.get<{ dividends: FundDividend[]; count: number }>(`/funds/${id}/dividends`),
+    benchmark: () =>
+      axiosInstance.get<{ benchmark: BenchmarkPoint[]; count: number }>('/funds/benchmark'),
+    setDividendPolicy: (id: number, policy: FundDividendPolicy) =>
+      axiosInstance.put<{ fundId: number; dividendPolicy: FundDividendPolicy }>(
+        `/funds/${id}/dividend-policy`,
+        { policy },
+      ),
+    runDividends: () =>
+      axiosInstance.post<{ period: string; eligible: number; processed: number; skipped: number; failed: number }>(
+        '/funds/dividends/run',
       ),
     invest: (fundId: number, payload: InvestInFundPayload) =>
       axiosInstance.post(`/funds/${fundId}/invest`, payload),

--- a/src/views/EmployeeFundDetailView.vue
+++ b/src/views/EmployeeFundDetailView.vue
@@ -19,6 +19,9 @@ import {
   type FundSummary,
   type FundHolding,
   type FundPerformancePoint,
+  type FundStatistics,
+  type FundDividend,
+  type FundDividendPolicy,
 } from '../api/fund'
 import { accountApi } from '../api/account'
 import { useAuthStore } from '../stores/auth'
@@ -34,6 +37,9 @@ const fund = ref<FundSummary | null>(null)
 const holdings = ref<FundHolding[]>([])
 const performance = ref<FundPerformancePoint[]>([])
 const granularity = ref<'monthly' | 'quarterly' | 'yearly'>('monthly')
+const statistics = ref<FundStatistics | null>(null)
+const dividends = ref<FundDividend[]>([])
+const policyBusy = ref(false)
 const loading = ref(false)
 const errorMsg = ref('')
 
@@ -52,14 +58,18 @@ async function load() {
   loading.value = true
   errorMsg.value = ''
   try {
-    const [fundRes, holdingsRes, perfRes] = await Promise.all([
+    const [fundRes, holdingsRes, perfRes, statsRes, divRes] = await Promise.all([
       fundApi.get(fundId.value),
       fundApi.holdings(fundId.value),
       fundApi.performance(fundId.value, granularity.value),
+      fundApi.statistics(fundId.value),
+      fundApi.dividends(fundId.value),
     ])
     fund.value = fundRes.data?.fund ?? null
     holdings.value = holdingsRes.data?.holdings ?? []
     performance.value = perfRes.data?.performance ?? []
+    statistics.value = statsRes.data?.statistics ?? null
+    dividends.value = divRes.data?.dividends ?? []
   } catch (err: any) {
     errorMsg.value = err?.response?.data?.message ?? 'Greska pri ucitavanju fonda.'
   } finally {
@@ -120,6 +130,23 @@ async function submitInvestForBank() {
   }
 }
 
+async function changeDividendPolicy(policy: FundDividendPolicy) {
+  if (!fund.value || fund.value.dividendPolicy === policy) return
+  policyBusy.value = true
+  try {
+    await fundApi.setDividendPolicy(fundId.value, policy)
+    fund.value.dividendPolicy = policy
+  } catch (err: any) {
+    errorMsg.value = err?.response?.data?.message ?? 'Greska pri promeni politike dividendi.'
+  } finally {
+    policyBusy.value = false
+  }
+}
+
+function fmtPct(v: number) {
+  return `${(v * 100).toFixed(2)} %`
+}
+
 const chartData = computed<ChartData<'line'>>(() => ({
   labels: performance.value.map((p) => p.date),
   datasets: [
@@ -173,7 +200,37 @@ onMounted(async () => {
           <button class="btn-primary" @click="investOpen = true">Uplati za banku</button>
           <button v-if="isManager" class="btn-secondary" @click="router.push('/securities')">Kupi hartiju za fond</button>
         </div>
+        <div class="policy-row">
+          <span class="policy-label">Politika dividendi:</span>
+          <template v-if="isManager">
+            <button
+              class="policy-btn"
+              :class="{ active: fund.dividendPolicy === 'reinvest' }"
+              :disabled="policyBusy"
+              @click="changeDividendPolicy('reinvest')"
+            >Reinvestiranje</button>
+            <button
+              class="policy-btn"
+              :class="{ active: fund.dividendPolicy === 'payout' }"
+              :disabled="policyBusy"
+              @click="changeDividendPolicy('payout')"
+            >Isplata klijentima</button>
+          </template>
+          <strong v-else>{{ fund.dividendPolicy === 'payout' ? 'Isplata klijentima' : 'Reinvestiranje' }}</strong>
+        </div>
       </header>
+
+      <section class="card">
+        <h2>Statistika fonda</h2>
+        <div v-if="statistics?.available" class="kpi-grid">
+          <div class="kpi"><span>Godišnji prinos</span><strong :class="statistics.annualizedReturn >= 0 ? 'positive' : 'negative'">{{ fmtPct(statistics.annualizedReturn) }}</strong></div>
+          <div class="kpi"><span>Prinos/rizik</span><strong>{{ statistics.rewardToVariability.toFixed(2) }}</strong></div>
+          <div class="kpi"><span>Max drawdown</span><strong class="negative">{{ fmtPct(statistics.maxDrawdown) }}</strong></div>
+          <div class="kpi"><span>Volatilnost</span><strong>{{ fmtPct(statistics.volatility) }}</strong></div>
+          <div class="kpi"><span>Meseci podataka</span><strong>{{ statistics.monthsOfData }}</strong></div>
+        </div>
+        <p v-else class="hint">Nedovoljno istorijskih podataka za prikaz metrika.</p>
+      </section>
 
       <section class="card">
         <div class="section-header">
@@ -215,6 +272,31 @@ onMounted(async () => {
         </table>
         <p v-else class="hint">Fond jos uvek nema hartija.</p>
       </section>
+
+      <section class="card">
+        <h2>Dividende fonda</h2>
+        <table v-if="dividends.length > 0" class="data-table">
+          <thead>
+            <tr>
+              <th>Datum</th><th>Period</th><th>Hartija</th>
+              <th class="num">Bruto (RSD)</th><th>Politika</th>
+              <th class="num">Reinvestirano</th><th class="num">Isplaćeno (RSD)</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="d in dividends" :key="d.id">
+              <td>{{ new Date(d.paidAt).toLocaleDateString('sr-RS') }}</td>
+              <td>{{ d.period }}</td>
+              <td><strong>{{ d.ticker }}</strong></td>
+              <td class="num">{{ d.grossRSD.toFixed(2) }}</td>
+              <td>{{ d.policy === 'payout' ? 'Isplata' : 'Reinvestiranje' }}</td>
+              <td class="num">{{ d.reinvestedShares > 0 ? `${d.reinvestedShares} kom (${d.reinvestedRSD.toFixed(2)})` : '—' }}</td>
+              <td class="num">{{ d.distributedRSD > 0 ? d.distributedRSD.toFixed(2) : '—' }}</td>
+            </tr>
+          </tbody>
+        </table>
+        <p v-else class="hint">Fond još uvek nije primio dividende.</p>
+      </section>
     </template>
 
     <!-- Invest-for-bank modal -->
@@ -253,6 +335,11 @@ onMounted(async () => {
 .kpi span { display: block; color: #64748b; font-size: 12px; text-transform: uppercase; letter-spacing: 0.04em; margin-bottom: 4px; }
 .kpi strong { font-size: 18px; color: #0f172a; }
 .actions { display: flex; gap: 10px; }
+.policy-row { display: flex; align-items: center; gap: 10px; margin-top: 16px; flex-wrap: wrap; }
+.policy-label { color: #64748b; font-size: 13px; font-weight: 600; }
+.policy-btn { padding: 7px 14px; border: 1px solid #cbd5e1; border-radius: 999px; background: #fff; color: #475569; font-weight: 600; font-size: 13px; cursor: pointer; }
+.policy-btn.active { background: #0f172a; color: #fff; border-color: #0f172a; }
+.policy-btn:disabled { opacity: 0.6; cursor: not-allowed; }
 .section-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 16px; }
 .section-header select { padding: 7px 12px; border: 1px solid #cbd5e1; border-radius: 8px; font-size: 13px; }
 .chart-wrapper { position: relative; height: 320px; }

--- a/src/views/client/ClientFundDetailView.vue
+++ b/src/views/client/ClientFundDetailView.vue
@@ -19,6 +19,9 @@ import {
   type FundSummary,
   type FundHolding,
   type FundPerformancePoint,
+  type FundStatistics,
+  type FundDividend,
+  type BenchmarkPoint,
 } from '../../api/fund'
 import { clientAccountApi } from '../../api/clientAccount'
 import { useClientAuthStore } from '../../stores/clientAuth'
@@ -34,6 +37,9 @@ const fund = ref<FundSummary | null>(null)
 const holdings = ref<FundHolding[]>([])
 const performance = ref<FundPerformancePoint[]>([])
 const granularity = ref<'monthly' | 'quarterly' | 'yearly'>('monthly')
+const statistics = ref<FundStatistics | null>(null)
+const dividends = ref<FundDividend[]>([])
+const benchmark = ref<BenchmarkPoint[]>([])
 
 const loading = ref(false)
 const errorMsg = ref('')
@@ -53,14 +59,20 @@ async function load() {
   loading.value = true
   errorMsg.value = ''
   try {
-    const [fundRes, holdingsRes, perfRes] = await Promise.all([
+    const [fundRes, holdingsRes, perfRes, statsRes, divRes, benchRes] = await Promise.all([
       clientFundApi.get(fundId.value),
       clientFundApi.holdings(fundId.value),
       clientFundApi.performance(fundId.value, granularity.value),
+      clientFundApi.statistics(fundId.value),
+      clientFundApi.dividends(fundId.value),
+      clientFundApi.benchmark(),
     ])
     fund.value = fundRes.data?.fund ?? null
     holdings.value = holdingsRes.data?.holdings ?? []
     performance.value = perfRes.data?.performance ?? []
+    statistics.value = statsRes.data?.statistics ?? null
+    dividends.value = divRes.data?.dividends ?? []
+    benchmark.value = benchRes.data?.benchmark ?? []
   } catch (err: any) {
     errorMsg.value = err?.response?.data?.message ?? 'Greska pri ucitavanju fonda.'
   } finally {
@@ -169,6 +181,51 @@ const chartOptions: ChartOptions<'line'> = {
   },
 }
 
+// Comparison chart: this fund rebased to 100 at the start of the shown window,
+// overlaid against the system-wide average fund index (also rebased to 100).
+const comparisonChartData = computed<ChartData<'line'>>(() => {
+  const perf = performance.value
+  const base = perf.length > 0 ? perf[0]!.fundValue : 0
+  const benchByDate = new Map(benchmark.value.map((b) => [b.date, b.indexValue]))
+  return {
+    labels: perf.map((p) => p.date),
+    datasets: [
+      {
+        label: 'Ovaj fond (index 100)',
+        data: perf.map((p) => (base > 0 ? (p.fundValue / base) * 100 : 100)),
+        borderColor: '#2563eb',
+        backgroundColor: 'rgba(37,99,235,0.08)',
+        borderWidth: 2,
+        pointRadius: 2,
+        tension: 0.3,
+      },
+      {
+        label: 'Prosek svih fondova',
+        data: perf.map((p) => benchByDate.get(p.date) ?? null),
+        borderColor: '#f59e0b',
+        backgroundColor: 'rgba(245,158,11,0.06)',
+        borderWidth: 2,
+        borderDash: [6, 4],
+        pointRadius: 0,
+        tension: 0.3,
+        spanGaps: true,
+      },
+    ],
+  }
+})
+const comparisonChartOptions: ChartOptions<'line'> = {
+  responsive: true,
+  maintainAspectRatio: false,
+  plugins: { legend: { display: true, position: 'bottom' }, tooltip: { enabled: true } },
+  scales: { x: { grid: { display: false } }, y: { ticks: { callback: (v: any) => Number(v).toFixed(0) } } },
+}
+
+const hasComparison = computed(() => performance.value.length > 1 && benchmark.value.length > 0)
+
+function fmtPct(v: number) {
+  return `${(v * 100).toFixed(2)} %`
+}
+
 onMounted(async () => {
   await load()
   await loadAccounts()
@@ -192,6 +249,7 @@ onMounted(async () => {
           <div class="kpi"><span>Profit</span><strong :class="fund.profitRSD >= 0 ? 'positive' : 'negative'">{{ fund.profitRSD.toFixed(2) }} RSD</strong></div>
           <div class="kpi"><span>Minimalni ulog</span><strong>{{ fund.minimalniUlog.toFixed(2) }} RSD</strong></div>
           <div class="kpi"><span>Ucesnika</span><strong>{{ fund.participantsCount }}</strong></div>
+          <div class="kpi"><span>Dividende</span><strong>{{ fund.dividendPolicy === 'payout' ? 'Isplata' : 'Reinvestiranje' }}</strong></div>
         </div>
         <div class="actions">
           <button class="btn-primary" @click="investOpen = true">Uplati u fond</button>
@@ -211,6 +269,26 @@ onMounted(async () => {
         <div class="chart-wrapper">
           <Line v-if="performance.length > 0" :data="chartData" :options="chartOptions" />
           <p v-else class="hint">Nema istorijskih podataka.</p>
+        </div>
+      </section>
+
+      <section class="card">
+        <h2>Statistika fonda</h2>
+        <div v-if="statistics?.available" class="kpi-grid">
+          <div class="kpi"><span>Godišnji prinos</span><strong :class="statistics.annualizedReturn >= 0 ? 'positive' : 'negative'">{{ fmtPct(statistics.annualizedReturn) }}</strong></div>
+          <div class="kpi"><span>Prinos/rizik</span><strong>{{ statistics.rewardToVariability.toFixed(2) }}</strong></div>
+          <div class="kpi"><span>Max drawdown</span><strong class="negative">{{ fmtPct(statistics.maxDrawdown) }}</strong></div>
+          <div class="kpi"><span>Volatilnost</span><strong>{{ fmtPct(statistics.volatility) }}</strong></div>
+          <div class="kpi"><span>Meseci podataka</span><strong>{{ statistics.monthsOfData }}</strong></div>
+        </div>
+        <p v-else class="hint">Nedovoljno istorijskih podataka za prikaz metrika (potrebno je više mesečnih snimaka).</p>
+      </section>
+
+      <section class="card">
+        <h2>Uporedni prikaz sa prosekom svih fondova</h2>
+        <div class="chart-wrapper">
+          <Line v-if="hasComparison" :data="comparisonChartData" :options="comparisonChartOptions" />
+          <p v-else class="hint">Nema dovoljno podataka za uporedni prikaz.</p>
         </div>
       </section>
 
@@ -239,6 +317,31 @@ onMounted(async () => {
           </tbody>
         </table>
         <p v-else class="hint">Fond jos uvek nema hartija.</p>
+      </section>
+
+      <section class="card">
+        <h2>Dividende fonda</h2>
+        <table v-if="dividends.length > 0" class="data-table">
+          <thead>
+            <tr>
+              <th>Datum</th><th>Period</th><th>Hartija</th>
+              <th class="num">Bruto (RSD)</th><th>Politika</th>
+              <th class="num">Reinvestirano</th><th class="num">Isplaćeno (RSD)</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="d in dividends" :key="d.id">
+              <td>{{ new Date(d.paidAt).toLocaleDateString('sr-RS') }}</td>
+              <td>{{ d.period }}</td>
+              <td><strong>{{ d.ticker }}</strong></td>
+              <td class="num">{{ d.grossRSD.toFixed(2) }}</td>
+              <td>{{ d.policy === 'payout' ? 'Isplata' : 'Reinvestiranje' }}</td>
+              <td class="num">{{ d.reinvestedShares > 0 ? `${d.reinvestedShares} kom (${d.reinvestedRSD.toFixed(2)})` : '—' }}</td>
+              <td class="num">{{ d.distributedRSD > 0 ? d.distributedRSD.toFixed(2) : '—' }}</td>
+            </tr>
+          </tbody>
+        </table>
+        <p v-else class="hint">Fond još uvek nije primio dividende.</p>
       </section>
     </template>
 

--- a/src/views/client/ClientFundsView.vue
+++ b/src/views/client/ClientFundsView.vue
@@ -10,8 +10,16 @@ const myPositions = ref<FundPositionView[]>([])
 const loading = ref(false)
 const errorMsg = ref('')
 
-const sortKey = ref<'naziv' | 'value' | 'profit' | 'minimalni'>('naziv')
+type SortKey =
+  | 'naziv' | 'value' | 'profit' | 'minimalni'
+  | 'annualized' | 'rtv' | 'drawdown' | 'volatility'
+const sortKey = ref<SortKey>('naziv')
 const search = ref('')
+
+// Sort helper: funds without enough history sort last on metric columns.
+function metric(f: FundSummary, key: 'annualizedReturn' | 'rewardToVariability' | 'maxDrawdown' | 'volatility') {
+  return f.statistics?.available ? f.statistics[key] : Number.NEGATIVE_INFINITY
+}
 
 const filtered = computed(() => {
   let rows = [...funds.value]
@@ -24,11 +32,22 @@ const filtered = computed(() => {
       case 'value': return b.fundValueRSD - a.fundValueRSD
       case 'profit': return b.profitRSD - a.profitRSD
       case 'minimalni': return a.minimalniUlog - b.minimalniUlog
+      case 'annualized': return metric(b, 'annualizedReturn') - metric(a, 'annualizedReturn')
+      case 'rtv': return metric(b, 'rewardToVariability') - metric(a, 'rewardToVariability')
+      case 'drawdown': return metric(a, 'maxDrawdown') - metric(b, 'maxDrawdown') // lower is better
+      case 'volatility': return metric(a, 'volatility') - metric(b, 'volatility') // lower is better
       default: return a.naziv.localeCompare(b.naziv)
     }
   })
   return rows
 })
+
+function fmtPct(v: number) {
+  return `${(v * 100).toFixed(2)} %`
+}
+function fmtRatio(v: number) {
+  return v.toFixed(2)
+}
 
 async function load() {
   loading.value = true
@@ -74,6 +93,10 @@ onMounted(load)
           <option value="value">Sortiraj: vrednost</option>
           <option value="profit">Sortiraj: profit</option>
           <option value="minimalni">Sortiraj: minimalni ulog</option>
+          <option value="annualized">Sortiraj: godišnji prinos</option>
+          <option value="rtv">Sortiraj: prinos/rizik</option>
+          <option value="drawdown">Sortiraj: max drawdown</option>
+          <option value="volatility">Sortiraj: volatilnost</option>
         </select>
       </div>
       <div v-if="loading" class="hint">Ucitavam...</div>
@@ -81,19 +104,33 @@ onMounted(load)
         <thead>
           <tr>
             <th>Naziv</th>
-            <th>Opis</th>
             <th class="num">Vrednost (RSD)</th>
             <th class="num">Profit (RSD)</th>
+            <th class="num" title="Anualizovani prinos">God. prinos</th>
+            <th class="num" title="Reward-to-variability (prinos/rizik); više je bolje">Prinos/rizik</th>
+            <th class="num" title="Najveći pad od vrha do dna; niže je bolje">Max drawdown</th>
+            <th class="num" title="Anualizovana volatilnost mesečnih prinosa">Volatilnost</th>
             <th class="num">Min. ulog</th>
             <th></th>
           </tr>
         </thead>
         <tbody>
           <tr v-for="f in filtered" :key="f.id" class="clickable" @click="openFund(f.id)">
-            <td><strong>{{ f.naziv }}</strong></td>
-            <td class="muted">{{ f.opis }}</td>
+            <td>
+              <strong>{{ f.naziv }}</strong>
+              <div class="muted desc">{{ f.opis }}</div>
+            </td>
             <td class="num">{{ f.fundValueRSD.toFixed(2) }}</td>
             <td class="num" :class="f.profitRSD >= 0 ? 'positive' : 'negative'">{{ f.profitRSD.toFixed(2) }}</td>
+            <template v-if="f.statistics?.available">
+              <td class="num" :class="f.statistics.annualizedReturn >= 0 ? 'positive' : 'negative'">{{ fmtPct(f.statistics.annualizedReturn) }}</td>
+              <td class="num">{{ fmtRatio(f.statistics.rewardToVariability) }}</td>
+              <td class="num negative">{{ fmtPct(f.statistics.maxDrawdown) }}</td>
+              <td class="num">{{ fmtPct(f.statistics.volatility) }}</td>
+            </template>
+            <template v-else>
+              <td class="num muted" colspan="4" title="Nedovoljno istorijskih podataka">—</td>
+            </template>
             <td class="num">{{ f.minimalniUlog.toFixed(2) }}</td>
             <td><button class="btn-primary" @click.stop="openFund(f.id)">Investiraj</button></td>
           </tr>
@@ -152,6 +189,7 @@ onMounted(load)
 .data-table tr.clickable { cursor: pointer; }
 .data-table tr.clickable:hover td { background: #f8fafc; }
 .muted { color: #64748b; }
+.desc { font-size: 12px; margin-top: 2px; max-width: 280px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .positive { color: #16a34a; }
 .negative { color: #dc2626; }
 .btn-primary { padding: 6px 14px; border-radius: 8px; border: none; background: #2563eb; color: #fff; font-weight: 600; cursor: pointer; font-size: 13px; }


### PR DESCRIPTION
- Discovery (ClientFundsView): sortable columns for annualized return, reward-to-variability, max drawdown, volatility (with insufficient-data state).
- Detail (Client + Employee): statistics KPIs, fund-vs-average benchmark comparison chart, fund dividend history; employee managers get a dividend policy toggle (reinvest/payout).
- fund.ts: FundStatistics/FundDividend/BenchmarkPoint types + statistics, dividends, benchmark, setDividendPolicy, runDividends endpoints; dividendPolicy on FundSummary.

vue-tsc + vite build green.