### PR TITLE
test(cypress): add Celina 3 & 4 e2e specs from TODO_final

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,7 @@ lerna-debug.log*
 # OS files
 .DS_Store
 Thumbs.db
+
+# Cypress run artifacts
+cypress/videos/
+cypress/screenshots/

--- a/cypress/e2e/celina3/dividends-portfolio.cy.js
+++ b/cypress/e2e/celina3/dividends-portfolio.cy.js
@@ -1,0 +1,151 @@
+// Celina 3 — Isplata dividendi (dividend payout).
+//
+// A lightweight end-to-end check that the quarterly dividend feature surfaces
+// in the client portal:
+//   - A DividendPayout row (the exact record the payout cron writes) is seeded
+//     for a trading client that holds AAPL.
+//   - The client opens "Moj Portfolio" and the "Isplaćene dividende" panel
+//     renders the payout with period, gross, credited amount and the 15%
+//     capital-gains tax (RSD) — exactly the columns from §Celina 3.
+//
+// The holding + payout are seeded directly via dbExec (same approach as the
+// OTC/watchlist specs) so the recording shows the real portfolio page reading
+// the persisted dividend through the live API.
+
+import '../helpers/slowdown'
+import {
+  adminLogin,
+  createClient,
+  activateClient,
+  createAccount,
+  fetchCurrencies,
+  loginClientUi,
+} from '../helpers/banking'
+import { grantClientTrading, seedPublicHolding } from '../helpers/otc'
+import { lookupListingId } from '../helpers/orders'
+
+const TICKER = 'AAPL'
+const QUANTITY = 10
+const PRICE_PER_SHARE = 180
+const DIVIDEND_YIELD = 0.04 // 4% annual -> /4 per quarter
+const GROSS = PRICE_PER_SHARE * QUANTITY * (DIVIDEND_YIELD / 4) // = 18 USD
+const TAX_RSD = 31.5 // 15% of gross, converted to RSD (illustrative)
+const PERIOD = '2026-Q2'
+
+function seedDividendPayout({ assetId, userId, accountId }) {
+  const sql = `
+    INSERT INTO dividend_payouts
+      (asset_id, ticker, user_id, user_type, account_id, quantity,
+       price_per_share, dividend_yield, currency, gross_amount,
+       credited_amount, credited_currency, tax_rsd, period, paid_at, created_at)
+    VALUES
+      ($1, $2, $3, 'client', $4, $5, $6, $7, 'USD', $8, $8, 'USD', $9, $10, NOW(), NOW())
+    RETURNING id
+  `
+  return cy
+    .task('dbExec', {
+      sql,
+      params: [
+        assetId, TICKER, userId, accountId, QUANTITY,
+        PRICE_PER_SHARE, DIVIDEND_YIELD, GROSS, TAX_RSD, PERIOD,
+      ],
+    })
+    .then(({ rows }) => {
+      expect(rows[0]?.id, 'seeded dividend payout id').to.exist
+      return Number(rows[0].id)
+    })
+}
+
+function fetchPayouts(userId) {
+  return cy
+    .task('dbExec', {
+      sql: `SELECT ticker, period, gross_amount::float AS gross
+            FROM dividend_payouts
+            WHERE user_id = $1 AND user_type = 'client'`,
+      params: [Number(userId)],
+    })
+    .then(({ rows }) => rows)
+}
+
+describe('Celina 3 — Isplata dividendi', () => {
+  beforeEach(function () {
+    this.ctx = {}
+    adminLogin()
+      .then((token) => {
+        this.ctx.adminToken = token
+        return fetchCurrencies(token)
+      })
+      .then((currencies) => {
+        const usd = currencies.find((c) => c.kod === 'USD')
+        expect(usd, 'USD currency seeded').to.exist
+        this.ctx.usdId = usd.id
+        return lookupListingId(TICKER)
+      })
+      .then((assetId) => {
+        this.ctx.assetId = assetId
+        return createClient(this.ctx.adminToken, 'c3-dividends')
+      })
+      .then((client) => {
+        this.ctx.client = client
+        return activateClient(client.setupToken)
+      })
+      .then(() => grantClientTrading(this.ctx.adminToken, this.ctx.client.id))
+      .then(() =>
+        createAccount(
+          this.ctx.adminToken,
+          this.ctx.client.id,
+          this.ctx.usdId,
+          `CYP-DIV-USD-${Date.now()}`,
+          1000,
+          { tip: 'devizni' }
+        )
+      )
+      .then((account) => {
+        this.ctx.account = account
+        // The portfolio page only renders its sub-panels (incl. dividends) once
+        // the client holds at least one position, so seed the AAPL holding too.
+        return seedPublicHolding({
+          userId: Number(this.ctx.client.id),
+          userType: 'client',
+          assetId: this.ctx.assetId,
+          accountId: Number(account.id),
+          quantity: QUANTITY,
+          publicQuantity: 0,
+          avgBuyPrice: 150,
+        })
+      })
+      .then(() =>
+        seedDividendPayout({
+          assetId: this.ctx.assetId,
+          userId: Number(this.ctx.client.id),
+          accountId: Number(this.ctx.account.id),
+        })
+      )
+      .then(() => loginClientUi(this.ctx.client.email))
+  })
+
+  it('Klijent vidi isplaćenu dividendu u portfoliju', function () {
+    const ctx = this.ctx
+
+    cy.visit('/client/portfolio')
+    cy.contains('h2', 'Isplaćene dividende').should('be.visible')
+
+    // The seeded payout row is rendered with the §Celina 3 columns.
+    cy.contains('.dividend-panel tr', TICKER).within(() => {
+      cy.contains(PERIOD).should('be.visible')
+      cy.get('.ticker').should('contain', TICKER)
+      // Gross 18.00 USD credited as 18.00 USD; 4.00% yield; tax in RSD.
+      cy.contains('18.00').should('exist')
+      cy.contains('4.00%').should('be.visible')
+      cy.contains(TAX_RSD.toFixed(2)).should('be.visible')
+    })
+
+    // Persisted exactly once for this client.
+    cy.then(() => fetchPayouts(ctx.client.id)).then((rows) => {
+      expect(rows).to.have.length(1)
+      expect(rows[0].ticker).to.eq(TICKER)
+      expect(rows[0].period).to.eq(PERIOD)
+      expect(Number(rows[0].gross)).to.be.closeTo(GROSS, 0.01)
+    })
+  })
+})

--- a/cypress/e2e/celina3/orders-notifications.cy.js
+++ b/cypress/e2e/celina3/orders-notifications.cy.js
@@ -1,0 +1,168 @@
+// Celina 3 — Notifikacije o orderima + Istorija ordera ("Moji orderi").
+//
+// Two end-to-end checks for the order-lifecycle features of §Celina 3:
+//   1) Placing an order emits an in-app + email notification to the client
+//      ("Kada agent/klijent kreira order"). We place a real market buy via the
+//      live order API, wait for the ORDER_CREATED notification to propagate
+//      through notification-service, then open the bell and confirm the email
+//      landed in MailHog.
+//   2) The order shows up in the client's own order history ("Istorija kupovina
+//      akcija" on the portfolio page) — clients can now see their past orders.
+//
+// The client + USD account are provisioned via the admin API; the order is
+// placed with the client's own JWT (read from sessionStorage after UI login).
+
+import '../helpers/slowdown'
+import {
+  adminLogin,
+  createClient,
+  activateClient,
+  createAccount,
+  fetchCurrencies,
+  loginClientUi,
+  API_BASE,
+} from '../helpers/banking'
+import { grantClientTrading, seedPublicHolding } from '../helpers/otc'
+import { createOrder, lookupListingId } from '../helpers/orders'
+
+const TICKER = 'AAPL'
+
+function authHeader(token) {
+  return { Authorization: `Bearer ${token}` }
+}
+
+// Read the client's access token straight from the session it logged in with.
+function clientToken() {
+  return cy.window().then((win) => win.sessionStorage.getItem('client_access_token'))
+}
+
+// Poll notification-service until the ORDER_CREATED notification has propagated.
+function waitForOrderNotification(token, attempt = 0) {
+  return cy
+    .request({ method: 'GET', url: `${API_BASE}/notifications`, headers: authHeader(token) })
+    .then(({ body }) => {
+      const list = Array.isArray(body) ? body : body.notifications || []
+      const hit = list.find((n) => n.type === 'ORDER_CREATED')
+      if (hit) return hit
+      if (attempt >= 15) throw new Error('ORDER_CREATED notification never arrived')
+      cy.wait(1000)
+      return waitForOrderNotification(token, attempt + 1)
+    })
+}
+
+// Poll MailHog for the order-created email addressed to the client.
+function waitForOrderEmail(email, attempt = 0) {
+  return cy.request('GET', 'http://localhost:8025/api/v2/messages').then(({ body }) => {
+    const match = (body.items || []).find((item) => {
+      const to = (item.Content?.Headers?.To || []).join(' ')
+      const text = item.Content?.Body || ''
+      return to.includes(email) && text.toLowerCase().includes('order')
+    })
+    if (match) return match
+    if (attempt >= 12) throw new Error(`order email never arrived for ${email}`)
+    cy.wait(1000)
+    return waitForOrderEmail(email, attempt + 1)
+  })
+}
+
+describe('Celina 3 — Notifikacije + istorija ordera', () => {
+  beforeEach(function () {
+    this.ctx = {}
+    const ctx = this.ctx
+    adminLogin()
+      .then((token) => {
+        ctx.adminToken = token
+        return fetchCurrencies(token)
+      })
+      .then((currencies) => {
+        const usd = currencies.find((c) => c.kod === 'USD')
+        expect(usd, 'USD currency seeded').to.exist
+        ctx.usdId = usd.id
+        return lookupListingId(TICKER)
+      })
+      .then((assetId) => {
+        ctx.assetId = assetId
+        return createClient(ctx.adminToken, 'c3-orders')
+      })
+      .then((client) => {
+        ctx.client = client
+        return activateClient(client.setupToken)
+      })
+      .then(() => grantClientTrading(ctx.adminToken, ctx.client.id))
+      .then(() =>
+        createAccount(ctx.adminToken, ctx.client.id, ctx.usdId, `CYP-ORD-USD-${Date.now()}`, 5000, {
+          tip: 'devizni',
+        })
+      )
+      .then((account) => {
+        ctx.account = account
+        loginClientUi(ctx.client.email)
+        return clientToken()
+      })
+      .then((token) => {
+        ctx.token = token
+      })
+  })
+
+  it('Klijent dobija in-app i email obaveštenje kada kreira order', function () {
+    const ctx = this.ctx
+
+    createOrder(ctx.token, {
+      assetTicker: TICKER,
+      orderType: 'market',
+      direction: 'buy',
+      quantity: 1,
+      accountId: Number(ctx.account.id),
+    }).then(({ status, body }) => {
+      expect(status, `order created (${JSON.stringify(body)})`).to.eq(201)
+    })
+
+    // The ORDER_CREATED notification propagates through notification-service.
+    waitForOrderNotification(ctx.token)
+
+    // The bell surfaces it in-app.
+    cy.visit('/client/dashboard')
+    cy.get('.notif-trigger').click()
+    cy.get('.notif-dropdown').within(() => {
+      cy.contains('.notif-item-title', 'Order kreiran').should('be.visible')
+      cy.contains('.notif-item-body', TICKER).should('be.visible')
+    })
+
+    // And the same notification was emailed to the client.
+    cy.then(() => waitForOrderEmail(ctx.client.email)).then((mail) => {
+      expect(mail, 'order email in MailHog').to.exist
+    })
+  })
+
+  it('Order se vidi u istoriji kupovina na portfoliju', function () {
+    const ctx = this.ctx
+
+    // A holding makes the portfolio render its panels; the placed order then
+    // shows up in the buy-order history list.
+    seedPublicHolding({
+      userId: Number(ctx.client.id),
+      userType: 'client',
+      assetId: ctx.assetId,
+      accountId: Number(ctx.account.id),
+      quantity: 5,
+      publicQuantity: 0,
+      avgBuyPrice: 150,
+    })
+
+    createOrder(ctx.token, {
+      assetTicker: TICKER,
+      orderType: 'market',
+      direction: 'buy',
+      quantity: 1,
+      accountId: Number(ctx.account.id),
+    }).then(({ status }) => {
+      expect(status).to.eq(201)
+    })
+
+    cy.visit('/client/portfolio')
+    cy.contains('h2', 'Istorija kupovina akcija').should('be.visible')
+    cy.get('.buy-history-panel').within(() => {
+      cy.contains(TICKER).should('be.visible')
+    })
+  })
+})

--- a/cypress/e2e/celina4/fund-dividends.cy.js
+++ b/cypress/e2e/celina4/fund-dividends.cy.js
@@ -1,0 +1,127 @@
+// Celina 4 — Raspodela dividendi u fondovima (fund dividend distribution).
+//
+// When a stock a fund holds pays a dividend, the cash flows into the fund and is
+// then either reinvested (auto-buying more shares) or paid out pro-rata to the
+// fund's participants. This spec seeds both kinds of FundDividend rows against a
+// pre-seeded fund and confirms the fund detail page's "Dividende fonda" section
+// renders them with the right policy, reinvested shares and distributed cash.
+//
+// Seeding directly is intentional: triggering a real fund dividend requires the
+// quarterly cron + a fund that actually owns a dividend-paying stock. The
+// assertions still drive the real client UI reading the persisted records.
+
+import '../helpers/slowdown'
+import {
+  adminLogin,
+  createClient,
+  activateClient,
+  loginClientUi,
+} from '../helpers/banking'
+import { grantClientTrading } from '../helpers/otc'
+import { lookupListingId } from '../helpers/orders'
+
+const TICKER = 'AAPL'
+
+// A fund pre-seeded in bankdb (id 1 = "TestFond").
+function firstFundId() {
+  return cy
+    .task('dbExec', { sql: 'SELECT id FROM investment_funds ORDER BY id LIMIT 1', params: [] })
+    .then(({ rows }) => {
+      expect(rows[0]?.id, 'a seeded fund exists').to.exist
+      return Number(rows[0].id)
+    })
+}
+
+function seedFundDividend({ fundId, assetId, period, policy, grossRSD, reinvestedShares, reinvestedRSD, distributedRSD }) {
+  const sql = `
+    INSERT INTO fund_dividends
+      (fund_id, asset_id, ticker, period, quantity, gross_rsd, policy,
+       reinvested_shares, reinvested_rsd, distributed_rsd, paid_at, created_at)
+    VALUES
+      ($1, $2, $3, $4, 100, $5, $6, $7, $8, $9, NOW(), NOW())
+    ON CONFLICT DO NOTHING
+    RETURNING id
+  `
+  return cy.task('dbExec', {
+    sql,
+    params: [fundId, assetId, TICKER, period, grossRSD, policy, reinvestedShares, reinvestedRSD, distributedRSD],
+  })
+}
+
+function cleanupFundDividends(fundId) {
+  return cy.task('dbExec', {
+    sql: "DELETE FROM fund_dividends WHERE fund_id = $1 AND ticker = $2 AND period IN ('CYP-Q1','CYP-Q2')",
+    params: [fundId, TICKER],
+  })
+}
+
+describe('Celina 4 — Raspodela dividendi u fondovima', () => {
+  beforeEach(function () {
+    this.ctx = {}
+    const ctx = this.ctx
+    adminLogin()
+      .then((token) => {
+        ctx.adminToken = token
+        return lookupListingId(TICKER)
+      })
+      .then((assetId) => {
+        ctx.assetId = assetId
+        return firstFundId()
+      })
+      .then((fundId) => {
+        ctx.fundId = fundId
+        return cleanupFundDividends(fundId) // keep the test idempotent
+      })
+      .then(() => createClient(ctx.adminToken, 'c4-funddiv'))
+      .then((client) => {
+        ctx.client = client
+        return activateClient(client.setupToken)
+      })
+      .then(() => grantClientTrading(ctx.adminToken, ctx.client.id))
+      .then(() => loginClientUi(ctx.client.email))
+  })
+
+  afterEach(function () {
+    if (this.ctx.fundId) cleanupFundDividends(this.ctx.fundId)
+  })
+
+  it('Detalji fonda prikazuju reinvestirane i isplaćene dividende', function () {
+    const ctx = this.ctx
+
+    // One reinvested dividend, one paid-out dividend.
+    seedFundDividend({
+      fundId: ctx.fundId, assetId: ctx.assetId, period: 'CYP-Q1', policy: 'reinvest',
+      grossRSD: 5000, reinvestedShares: 20, reinvestedRSD: 5000, distributedRSD: 0,
+    })
+    seedFundDividend({
+      fundId: ctx.fundId, assetId: ctx.assetId, period: 'CYP-Q2', policy: 'payout',
+      grossRSD: 6000, reinvestedShares: 0, reinvestedRSD: 0, distributedRSD: 6000,
+    })
+
+    cy.visit(`/client/funds/${ctx.fundId}`)
+    cy.contains('h2', 'Dividende fonda').should('be.visible')
+
+    // Reinvested row: policy "Reinvestiranje" + the bought shares.
+    cy.contains('.data-table tr', 'CYP-Q1').within(() => {
+      cy.contains(TICKER).should('be.visible')
+      cy.contains('Reinvestiranje').should('be.visible')
+      cy.contains('20 kom').should('be.visible')
+    })
+
+    // Payout row: policy "Isplata" + distributed RSD.
+    cy.contains('.data-table tr', 'CYP-Q2').within(() => {
+      cy.contains('Isplata').should('be.visible')
+      cy.contains('6000.00').should('be.visible')
+    })
+
+    // Persisted both dividend records on the fund.
+    cy.then(() =>
+      cy.task('dbExec', {
+        sql: "SELECT policy FROM fund_dividends WHERE fund_id = $1 AND period IN ('CYP-Q1','CYP-Q2') ORDER BY period",
+        params: [ctx.fundId],
+      })
+    ).then(({ rows }) => {
+      expect(rows.map((r) => r.policy)).to.deep.eq(['reinvest', 'payout'])
+    })
+  })
+})

--- a/cypress/e2e/celina4/negotiation-history-and-funds.cy.js
+++ b/cypress/e2e/celina4/negotiation-history-and-funds.cy.js
@@ -1,0 +1,217 @@
+// Celina 4 — Istorija pregovora (OTC negotiation history) + Statistika fondova.
+//
+// Two lightweight end-to-end checks for the Celina 4 backlog:
+//
+//   1) Istorija pregovora: a finished (declined) OTC offer with a full
+//      negotiation log — initial offer → counter-offer → decline — is seeded,
+//      then the buyer opens "/client/otc/negotiations", sees the offer, expands
+//      it, and the timeline renders each step with the old→new term changes
+//      ("bilo 170.00") that §Celina 4 requires.
+//
+//   2) Statistika fondova: the funds discovery page exposes the four risk/return
+//      metrics from §Celina 4 (godišnji prinos, prinos/rizik, max drawdown,
+//      volatilnost) as sort options, proving the statistics feature is wired in.
+//
+// As with the other trading specs, OTC rows are seeded directly via dbExec
+// (placing real offers is too brittle) while assertions drive the real UI.
+
+import '../helpers/slowdown'
+import {
+  adminLogin,
+  createClient,
+  activateClient,
+  createAccount,
+  fetchCurrencies,
+  loginClientUi,
+} from '../helpers/banking'
+import { grantClientTrading, seedPublicHolding } from '../helpers/otc'
+import { lookupListingId } from '../helpers/orders'
+
+const TICKER = 'AAPL'
+
+function futureDateString(daysAhead) {
+  const d = new Date()
+  d.setDate(d.getDate() + daysAhead)
+  return d.toISOString().slice(0, 10)
+}
+
+function seedOffer({ ctx, settlement }) {
+  const sql = `
+    INSERT INTO otc_offers
+      (stock_listing_id, seller_holding_id, amount, price_per_stock,
+       settlement_date, premium, last_modified, modified_by_id, modified_by_type,
+       status, buyer_id, buyer_type, buyer_account_id,
+       seller_id, seller_type, seller_account_id, created_at, updated_at)
+    VALUES
+      ($1, $2, 2, 180, $3::date, 50, NOW(), $4, 'client',
+       'declined', $4, 'client', $5, $6, 'client', $7, NOW(), NOW())
+    RETURNING id
+  `
+  return cy
+    .task('dbExec', {
+      sql,
+      params: [
+        ctx.assetId,
+        ctx.sellerHoldingId,
+        settlement,
+        Number(ctx.buyer.id),
+        Number(ctx.buyerAccount.id),
+        Number(ctx.seller.id),
+        Number(ctx.sellerAccount.id),
+      ],
+    })
+    .then(({ rows }) => {
+      expect(rows[0]?.id, 'seeded otc offer id').to.exist
+      return Number(rows[0].id)
+    })
+}
+
+// Append the three negotiation steps: created (buyer), countered (seller,
+// carrying the prev terms), declined (buyer). created_at is staggered so the
+// timeline orders deterministically.
+function seedNegotiationLog({ offerId, ctx, settlement }) {
+  const sql = `
+    INSERT INTO otc_negotiation_entries
+      (offer_id, action, actor_id, actor_type, amount, price_per_stock, premium,
+       settlement_date, prev_amount, prev_price_per_stock, prev_premium,
+       prev_settlement_date, created_at)
+    VALUES
+      ($1, 'created',  $2, 'client', 2, 170, 40, $4::date, NULL, NULL, NULL, NULL, NOW() - interval '2 hours'),
+      ($1, 'countered',$3, 'client', 2, 180, 50, $4::date, 2,   170,  40,   $4::date, NOW() - interval '1 hour'),
+      ($1, 'declined', $2, 'client', 2, 180, 50, $4::date, NULL, NULL, NULL, NULL, NOW())
+  `
+  return cy.task('dbExec', {
+    sql,
+    params: [offerId, Number(ctx.buyer.id), Number(ctx.seller.id), settlement],
+  })
+}
+
+describe('Celina 4 — Istorija pregovora + Statistika fondova', () => {
+  beforeEach(function () {
+    this.ctx = {}
+    const ctx = this.ctx
+    adminLogin()
+      .then((token) => {
+        ctx.adminToken = token
+        return fetchCurrencies(token)
+      })
+      .then((currencies) => {
+        const usd = currencies.find((c) => c.kod === 'USD')
+        expect(usd, 'USD currency seeded').to.exist
+        ctx.usdId = usd.id
+        return lookupListingId(TICKER)
+      })
+      .then((assetId) => {
+        ctx.assetId = assetId
+        return createClient(ctx.adminToken, 'c4-seller')
+      })
+      .then((seller) => {
+        ctx.seller = seller
+        return activateClient(seller.setupToken)
+      })
+      .then(() => grantClientTrading(ctx.adminToken, ctx.seller.id))
+      .then(() =>
+        createAccount(ctx.adminToken, ctx.seller.id, ctx.usdId, `CYP-NEG-SELL-${Date.now()}`, 1000, {
+          tip: 'devizni',
+        })
+      )
+      .then((account) => {
+        ctx.sellerAccount = account
+        return createClient(ctx.adminToken, 'c4-buyer')
+      })
+      .then((buyer) => {
+        ctx.buyer = buyer
+        return activateClient(buyer.setupToken)
+      })
+      .then(() => grantClientTrading(ctx.adminToken, ctx.buyer.id))
+      .then(() =>
+        createAccount(ctx.adminToken, ctx.buyer.id, ctx.usdId, `CYP-NEG-BUY-${Date.now()}`, 5000, {
+          tip: 'devizni',
+        })
+      )
+      .then((account) => {
+        ctx.buyerAccount = account
+        return seedPublicHolding({
+          userId: Number(ctx.seller.id),
+          userType: 'client',
+          assetId: ctx.assetId,
+          accountId: Number(ctx.sellerAccount.id),
+          quantity: 5,
+          publicQuantity: 5,
+          avgBuyPrice: 150,
+        })
+      })
+      .then(({ holdingId }) => {
+        ctx.sellerHoldingId = holdingId
+      })
+  })
+
+  it('Kupac vidi istoriju pregovora sa timeline-om kontraponuda', function () {
+    const ctx = this.ctx
+    const settlement = futureDateString(30)
+
+    seedOffer({ ctx, settlement })
+      .then((offerId) => {
+        ctx.offerId = offerId
+        return seedNegotiationLog({ offerId, ctx, settlement })
+      })
+      .then(() => {
+        loginClientUi(ctx.buyer.email)
+        cy.visit('/client/otc/negotiations')
+        cy.contains('h1', 'Istorija pregovora').should('be.visible')
+
+        // The declined offer shows up with the buyer's role and ticker.
+        cy.contains('.otc-table tr', `#${ctx.offerId}`).within(() => {
+          cy.contains('Kupac').should('be.visible')
+          cy.get('.ticker').should('contain', TICKER)
+          cy.contains('.status-pill', 'Odbijena').should('be.visible')
+        })
+
+        // Expand the row -> the negotiation timeline.
+        cy.contains('.otc-table tr', `#${ctx.offerId}`).click()
+        cy.get('.history-row .timeline').within(() => {
+          cy.contains('.timeline-action', 'Inicijalna ponuda').should('be.visible')
+          cy.contains('.timeline-action', 'Kontraponuda').should('be.visible')
+          cy.contains('.timeline-action', 'Odbijeno').should('be.visible')
+          // The counter-offer records the prior price (170 -> 180).
+          cy.contains('bilo 170.00').should('be.visible')
+        })
+      })
+
+    // Persisted: three negotiation entries for this offer.
+    cy.then(() =>
+      cy.task('dbExec', {
+        sql: 'SELECT count(*)::int AS n FROM otc_negotiation_entries WHERE offer_id = $1',
+        params: [ctx.offerId],
+      })
+    ).then(({ rows }) => {
+      expect(rows[0].n).to.eq(3)
+    })
+  })
+
+  it('Stranica fondova nudi sortiranje po statistici (prinos, rizik, drawdown, volatilnost)', function () {
+    loginClientUi(this.ctx.buyer.email)
+    cy.visit('/client/funds')
+    cy.contains('h1', 'Investicioni fondovi').should('be.visible')
+
+    // The four §Celina 4 risk/return metrics are exposed as sort options.
+    cy.get('.filters select').within(() => {
+      cy.contains('option', 'godišnji prinos').should('exist')
+      cy.contains('option', 'prinos/rizik').should('exist')
+      cy.contains('option', 'max drawdown').should('exist')
+      cy.contains('option', 'volatilnost').should('exist')
+    })
+
+    // If any funds are seeded, the metric column headers render too.
+    cy.get('body').then(($body) => {
+      if ($body.find('.data-table').length) {
+        cy.get('.data-table thead').within(() => {
+          cy.contains('th', 'God. prinos').should('exist')
+          cy.contains('th', 'Prinos/rizik').should('exist')
+          cy.contains('th', 'Max drawdown').should('exist')
+          cy.contains('th', 'Volatilnost').should('exist')
+        })
+      }
+    })
+  })
+})

--- a/cypress/e2e/helpers/slowdown.js
+++ b/cypress/e2e/helpers/slowdown.js
@@ -1,0 +1,24 @@
+// Slow the test run down for more watchable recordings.
+//
+// Cypress has no literal "playback speed" knob — commands don't carry an
+// intrinsic duration you can scale by a percentage. The standard technique is
+// to insert a fixed delay before each interactive command. With the short
+// Celina specs a ~250 ms delay stretches the run to roughly three-quarters of
+// its natural pace (i.e. ~75% speed). Tune COMMAND_DELAY to taste — set it to 0
+// to disable.
+//
+// Note: only real "commands" can be overwritten this way. In Cypress 15
+// `contains`/`get` are queries (overwriteQuery), so they're intentionally left
+// out — delaying the action commands below is what visibly slows the playback.
+const COMMAND_DELAY = 250
+
+const slowedCommands = ['visit', 'click', 'trigger', 'type', 'clear', 'reload', 'select', 'check', 'uncheck']
+
+for (const command of slowedCommands) {
+  Cypress.Commands.overwrite(command, (originalFn, ...args) => {
+    const origVal = originalFn(...args)
+    return new Promise((resolve) => {
+      setTimeout(() => resolve(origVal), COMMAND_DELAY)
+    })
+  })
+}


### PR DESCRIPTION
Add end-to-end Cypress coverage for the implemented Celina 3 and 4 features:

Celina 3:
- Isplata dividendi: seeded DividendPayout renders in "Moj Portfolio".
- Order notifications: placing a market buy emits an in-app (bell) + email (MailHog) ORDER_CREATED notification through notification-service.
- Istorija ordera: the placed order appears in the client's buy-order history.

Celina 4:
- Istorija pregovora: OTC offer with a full negotiation log (created ->
  countered -> declined) renders as an expandable timeline with old->new terms.
- Raspodela dividendi u fondovima: reinvested + paid-out FundDividend rows show on the fund detail "Dividende fonda" section.
- Statistika fondova: the four risk/return metrics are exposed as sort options.

Add cypress/e2e/helpers/slowdown.js (per-command delay, ~75% playback pace) for more watchable recordings, and gitignore cypress run artifacts.