### PR TITLE
Fund/OTC UI: cross-bank OTC history, fund dividend proof, purchase-hi…

### DIFF
--- a/src/api/fund.ts
+++ b/src/api/fund.ts
@@ -49,6 +49,18 @@ export interface FundDividend {
   paidAt: string
 }
 
+export interface FundDividendPayout {
+  id: number
+  assetId: number
+  ticker: string
+  period: string
+  clientId: number
+  clientType: string
+  accountId: number
+  amountRSD: number
+  paidAt: string
+}
+
 export interface BenchmarkPoint {
   date: string
   indexValue: number
@@ -130,7 +142,9 @@ function fundApiFor(axiosInstance: typeof employeeApi) {
     statistics: (id: number) =>
       axiosInstance.get<{ statistics: FundStatistics }>(`/funds/${id}/statistics`),
     dividends: (id: number) =>
-      axiosInstance.get<{ dividends: FundDividend[]; count: number }>(`/funds/${id}/dividends`),
+      axiosInstance.get<{ dividends: FundDividend[]; count: number; payouts: FundDividendPayout[] }>(
+        `/funds/${id}/dividends`,
+      ),
     benchmark: () =>
       axiosInstance.get<{ benchmark: BenchmarkPoint[]; count: number }>('/funds/benchmark'),
     setDividendPolicy: (id: number, policy: FundDividendPolicy) =>

--- a/src/api/order.ts
+++ b/src/api/order.ts
@@ -48,6 +48,8 @@ export interface Order {
   status: OrderStatus
   isDone: boolean
   remainingPortions: number
+  /** Commission charged for the order, in the asset's trading currency. */
+  commission: number
   /** Amount actually debited from the user's account at order creation, in the account's currency. Zero on sell orders. */
   totalPaid: number
   /** Account balance immediately before the buy debit. Zero on sell orders. */

--- a/src/components/BuyOrderModal.vue
+++ b/src/components/BuyOrderModal.vue
@@ -160,11 +160,15 @@ async function loadAccounts() {
           balance: Number(a.raspolozivoStanje),
         }))
     } else {
-      // Employee: only bank (firma) accounts — exclude client accounts
+      // Employee: only bank (firma) accounts — exclude client accounts and
+      // investment-fund cash accounts (podvrsta='fondacija'). A fund account
+      // must only be traded through the "for fund" path, which swaps in the
+      // fund's account explicitly; the backend also rejects bank orders that
+      // target a fund account.
       const res = await accountApi.listAll({ status: 'aktivan', pageSize: 200 })
       const items: any[] = res.data?.accounts ?? res.data?.content ?? res.data ?? []
       accounts.value = items
-        .filter((a: any) => (!a.clientId || a.clientId === '0' || a.clientId === 0) && !a.naziv?.toLowerCase().includes('republika'))
+        .filter((a: any) => (!a.clientId || a.clientId === '0' || a.clientId === 0) && !a.naziv?.toLowerCase().includes('republika') && a.podvrsta !== 'fondacija')
         .map((a: any) => ({
           id: Number(a.id),
           label: `${a.naziv || a.brojRacuna} (${a.currencyKod} ${Number(a.raspolozivoStanje).toFixed(2)})`,

--- a/src/views/EmployeeFundDetailView.vue
+++ b/src/views/EmployeeFundDetailView.vue
@@ -21,6 +21,7 @@ import {
   type FundPerformancePoint,
   type FundStatistics,
   type FundDividend,
+  type FundDividendPayout,
   type FundDividendPolicy,
 } from '../api/fund'
 import { accountApi } from '../api/account'
@@ -39,12 +40,16 @@ const performance = ref<FundPerformancePoint[]>([])
 const granularity = ref<'monthly' | 'quarterly' | 'yearly'>('monthly')
 const statistics = ref<FundStatistics | null>(null)
 const dividends = ref<FundDividend[]>([])
+const dividendPayouts = ref<FundDividendPayout[]>([])
 const policyBusy = ref(false)
 const loading = ref(false)
 const errorMsg = ref('')
 
 const isSupervisor = computed(() => auth.hasPermission('employeeSupervisor'))
 const isManager = computed(() => isSupervisor.value && fund.value?.managerId === auth.employee?.id)
+// The dividend policy is normally the managing supervisor's to set, but an admin
+// may override it on any fund (matches the backend admin override).
+const canManagePolicy = computed(() => isManager.value || auth.isAdmin())
 
 // Bank-invest dialog (supervisor on bank's behalf)
 const investOpen = ref(false)
@@ -70,6 +75,7 @@ async function load() {
     performance.value = perfRes.data?.performance ?? []
     statistics.value = statsRes.data?.statistics ?? null
     dividends.value = divRes.data?.dividends ?? []
+    dividendPayouts.value = divRes.data?.payouts ?? []
   } catch (err: any) {
     errorMsg.value = err?.response?.data?.message ?? 'Greska pri ucitavanju fonda.'
   } finally {
@@ -143,6 +149,26 @@ async function changeDividendPolicy(policy: FundDividendPolicy) {
   }
 }
 
+// Manual dividend run (manager only). The distribution is idempotent per
+// (fund, asset, quarter), so re-running in the same quarter reports the
+// already-paid holdings as "skipped" rather than paying twice.
+const dividendBusy = ref(false)
+const dividendMsg = ref('')
+async function runDividends() {
+  dividendBusy.value = true
+  dividendMsg.value = ''
+  try {
+    const res = await fundApi.runDividends()
+    const r = res.data
+    dividendMsg.value = `Period ${r.period}: ${r.processed} isplaćeno, ${r.skipped} preskočeno, ${r.failed} neuspešno (od ${r.eligible} podobnih).`
+    await load()
+  } catch (err: any) {
+    dividendMsg.value = err?.response?.data?.message ?? 'Greška pri pokretanju dividendi.'
+  } finally {
+    dividendBusy.value = false
+  }
+}
+
 function fmtPct(v: number) {
   return `${(v * 100).toFixed(2)} %`
 }
@@ -198,11 +224,11 @@ onMounted(async () => {
         </div>
         <div v-if="isSupervisor" class="actions">
           <button class="btn-primary" @click="investOpen = true">Uplati za banku</button>
-          <button v-if="isManager" class="btn-secondary" @click="router.push('/securities')">Kupi hartiju za fond</button>
+          <button v-if="canManagePolicy" class="btn-secondary" @click="router.push('/securities')">Kupi hartiju za fond</button>
         </div>
         <div class="policy-row">
           <span class="policy-label">Politika dividendi:</span>
-          <template v-if="isManager">
+          <template v-if="canManagePolicy">
             <button
               class="policy-btn"
               :class="{ active: fund.dividendPolicy === 'reinvest' }"
@@ -274,7 +300,13 @@ onMounted(async () => {
       </section>
 
       <section class="card">
-        <h2>Dividende fonda</h2>
+        <div class="card-head">
+          <h2>Dividende fonda</h2>
+          <button v-if="isSupervisor" class="btn-secondary" :disabled="dividendBusy" @click="runDividends">
+            {{ dividendBusy ? 'Pokrećem…' : 'Pokreni dividende' }}
+          </button>
+        </div>
+        <p v-if="dividendMsg" class="hint">{{ dividendMsg }}</p>
         <table v-if="dividends.length > 0" class="data-table">
           <thead>
             <tr>
@@ -296,6 +328,30 @@ onMounted(async () => {
           </tbody>
         </table>
         <p v-else class="hint">Fond još uvek nije primio dividende.</p>
+      </section>
+
+      <section class="card">
+        <h2>Isplate dividendi po učesniku</h2>
+        <p class="hint">Detaljan prikaz kome je i koliko isplaćeno (politika „Isplata“).</p>
+        <table v-if="dividendPayouts.length > 0" class="data-table">
+          <thead>
+            <tr>
+              <th>Datum</th><th>Period</th><th>Hartija</th>
+              <th>Učesnik</th><th>Račun</th><th class="num">Iznos (RSD)</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="p in dividendPayouts" :key="p.id">
+              <td>{{ new Date(p.paidAt).toLocaleDateString('sr-RS') }}</td>
+              <td>{{ p.period }}</td>
+              <td><strong>{{ p.ticker }}</strong></td>
+              <td>{{ p.clientType === 'bank' ? 'Banka' : `Klijent #${p.clientId}` }}</td>
+              <td>#{{ p.accountId }}</td>
+              <td class="num">{{ p.amountRSD.toFixed(2) }}</td>
+            </tr>
+          </tbody>
+        </table>
+        <p v-else class="hint">Još uvek nema isplata po učesniku (reinvestiranje ne proizvodi isplate).</p>
       </section>
     </template>
 
@@ -351,6 +407,9 @@ onMounted(async () => {
 .negative { color: #dc2626; }
 .btn-primary { padding: 9px 18px; border: none; border-radius: 10px; background: #2563eb; color: #fff; font-weight: 600; cursor: pointer; }
 .btn-secondary { padding: 9px 18px; border: 1px solid #cbd5e1; border-radius: 10px; background: #fff; color: #374151; font-weight: 600; cursor: pointer; }
+.btn-secondary:disabled { opacity: 0.6; cursor: not-allowed; }
+.card-head { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+.card-head h2 { margin: 0; }
 .error-box { background: #fef2f2; border: 1px solid #fca5a5; border-radius: 10px; padding: 10px 14px; color: #b91c1c; margin-bottom: 14px; }
 .hint { color: #64748b; text-align: center; padding: 20px 0; }
 .modal-overlay { position: fixed; inset: 0; background: rgba(15,23,42,0.45); display: flex; align-items: center; justify-content: center; z-index: 1000; padding: 16px; }

--- a/src/views/client/ClientOtcNegotiationHistoryView.vue
+++ b/src/views/client/ClientOtcNegotiationHistoryView.vue
@@ -8,10 +8,12 @@ import {
   type OtcOfferStatus,
   type OtcNegotiationEntry,
 } from '../../api/otc'
+import { interbankOtcApi, type InterbankNegotiation } from '../../api/interbankOtc'
 
 const authStore = useClientAuthStore()
 
-const negotiations = ref<OtcOffer[]>([])
+const offers = ref<OtcOffer[]>([])
+const crossBankNegotiations = ref<InterbankNegotiation[]>([])
 const loading = ref(false)
 const error = ref('')
 
@@ -21,8 +23,8 @@ const fromFilter = ref('')
 const toFilter = ref('')
 const counterpartyFilter = ref('')
 
-// Expanded-row history
-const expandedOfferId = ref<number | null>(null)
+// Expanded-row history (local offers only — cross-bank has no per-step timeline endpoint)
+const expandedKey = ref<string | null>(null)
 const historyEntries = ref<OtcNegotiationEntry[]>([])
 const historyLoading = ref(false)
 const historyError = ref('')
@@ -53,22 +55,39 @@ function fmtQuantity(value: number) {
   return quantityFormatter.format(value)
 }
 function fmtDate(value: string) {
-  return new Date(value).toLocaleDateString('sr-RS')
+  return value ? new Date(value).toLocaleDateString('sr-RS') : '—'
 }
 function fmtDateTime(value: string) {
-  return new Date(value).toLocaleString('sr-RS')
+  return value ? new Date(value).toLocaleString('sr-RS') : '—'
 }
 
-function isBuyer(offer: OtcOffer) {
+// ─── Unified negotiation row ───────────────────────────────────────────
+// Local and cross-bank negotiations have different shapes; we normalize
+// both into one row type so the history table can render them together.
+type NegotiationSource = 'local' | 'crossbank'
+
+interface UnifiedRow {
+  key: string
+  source: NegotiationSource
+  displayId: string
+  role: string
+  counterparty: string
+  counterpartyId: number
+  ticker: string
+  currency: string
+  amount: number
+  pricePerStock: number
+  premium: number
+  settlementDate: string
+  statusKey: string
+  statusLabel: string
+  lastModified: string
+  offer?: OtcOffer
+  crossBank?: InterbankNegotiation
+}
+
+function localIsBuyer(offer: OtcOffer) {
   return offer.buyerType === 'client' && offer.buyerId === currentClientId.value
-}
-function role(offer: OtcOffer) {
-  return isBuyer(offer) ? 'Kupac' : 'Prodavac'
-}
-function counterparty(offer: OtcOffer) {
-  return isBuyer(offer)
-    ? `#${offer.sellerId} / ${offer.sellerType}`
-    : `#${offer.buyerId} / ${offer.buyerType}`
 }
 
 function statusLabel(status: string) {
@@ -103,20 +122,132 @@ function actionLabel(action: string) {
   }
 }
 
+function localToRow(offer: OtcOffer): UnifiedRow {
+  const isBuyer = localIsBuyer(offer)
+  return {
+    key: `local-${offer.id}`,
+    source: 'local',
+    displayId: `#${offer.id}`,
+    role: isBuyer ? 'Kupac' : 'Prodavac',
+    counterparty: isBuyer
+      ? `#${offer.sellerId} / ${offer.sellerType}`
+      : `#${offer.buyerId} / ${offer.buyerType}`,
+    counterpartyId: isBuyer ? offer.sellerId : offer.buyerId,
+    ticker: offer.ticker,
+    currency: offer.exchange.currency,
+    amount: offer.amount,
+    pricePerStock: offer.pricePerStock,
+    premium: offer.premium,
+    settlementDate: offer.settlementDate,
+    statusKey: offer.status,
+    statusLabel: statusLabel(offer.status),
+    lastModified: offer.lastModified,
+    offer,
+  }
+}
+
+function crossBankToRow(neg: InterbankNegotiation): UnifiedRow {
+  const isBuyer = neg.localRole === 'buyer'
+  return {
+    key: `crossbank-${neg.negotiationRoutingNumber}-${neg.negotiationId}`,
+    source: 'crossbank',
+    displayId: `${neg.negotiationRoutingNumber}/${neg.negotiationId}`,
+    role: isBuyer ? 'Kupac' : 'Prodavac',
+    counterparty: `Banka ${neg.counterpartyRoutingNumber}`,
+    counterpartyId: neg.counterpartyRoutingNumber,
+    ticker: neg.stock.ticker,
+    currency: neg.pricePerUnit.currency,
+    amount: neg.amount,
+    pricePerStock: neg.pricePerUnit.amount,
+    premium: neg.premium.amount,
+    settlementDate: neg.settlementDate,
+    statusKey: neg.isOngoing ? 'ongoing' : 'closed',
+    statusLabel: neg.isOngoing ? 'U toku' : 'Zatvoren',
+    lastModified: neg.updatedAt,
+    crossBank: neg,
+  }
+}
+
+// crossBankMatchesStatus maps the local status filter onto the coarse
+// ongoing/closed distinction cross-bank negotiations carry. Ongoing rows
+// answer to "pending"; closed rows answer to the terminal statuses.
+function crossBankMatchesStatus(neg: InterbankNegotiation, status: OtcOfferStatus) {
+  switch (status) {
+    case '':
+      return true
+    case 'pending':
+      return neg.isOngoing
+    case 'accepted':
+    case 'declined':
+    case 'cancelled':
+      return !neg.isOngoing
+    default:
+      return true
+  }
+}
+
+// Cross-bank negotiations are filtered client-side: the local/from/to/
+// counterparty filters apply, but cross-bank only knows routing numbers
+// (counterparty) and an ongoing/closed flag (status).
+const filteredCrossBank = computed<UnifiedRow[]>(() => {
+  const from = fromFilter.value ? new Date(fromFilter.value) : null
+  const to = toFilter.value ? new Date(`${toFilter.value}T23:59:59`) : null
+  const cp = counterpartyFilter.value ? Number(counterpartyFilter.value) : null
+
+  return crossBankNegotiations.value
+    .filter((neg) => crossBankMatchesStatus(neg, statusFilter.value))
+    .filter((neg) => {
+      if (!from && !to) return true
+      const modified = new Date(neg.updatedAt)
+      if (from && modified < from) return false
+      if (to && modified > to) return false
+      return true
+    })
+    .filter((neg) => cp == null || neg.counterpartyRoutingNumber === cp)
+    .map(crossBankToRow)
+})
+
+const rows = computed<UnifiedRow[]>(() => {
+  const merged = [...offers.value.map(localToRow), ...filteredCrossBank.value]
+  return merged.sort(
+    (a, b) => new Date(b.lastModified).getTime() - new Date(a.lastModified).getTime(),
+  )
+})
+
 async function fetchNegotiations() {
   loading.value = true
   error.value = ''
-  expandedOfferId.value = null
+  expandedKey.value = null
   try {
-    const res = await otcApi.listNegotiations({
-      status: statusFilter.value || undefined,
-      from: fromFilter.value || undefined,
-      to: toFilter.value || undefined,
-      counterparty: counterpartyFilter.value ? Number(counterpartyFilter.value) : undefined,
-    })
-    negotiations.value = res.data.negotiations || []
-  } catch {
-    error.value = 'Nije moguće učitati istoriju pregovora.'
+    // Local negotiations honour the filters server-side. Cross-bank
+    // negotiations are fetched in full (ongoing + closed, both roles) and
+    // filtered client-side — see filteredCrossBank.
+    const [localRes, crossRes] = await Promise.allSettled([
+      otcApi.listNegotiations({
+        status: statusFilter.value || undefined,
+        from: fromFilter.value || undefined,
+        to: toFilter.value || undefined,
+        counterparty: counterpartyFilter.value ? Number(counterpartyFilter.value) : undefined,
+      }),
+      interbankOtcApi.listNegotiations('', true),
+    ])
+
+    if (localRes.status === 'fulfilled') {
+      offers.value = localRes.value.data.negotiations || []
+    } else {
+      offers.value = []
+      error.value = 'Nije moguće učitati lokalnu istoriju pregovora.'
+    }
+
+    if (crossRes.status === 'fulfilled') {
+      crossBankNegotiations.value = crossRes.value.data.negotiations || []
+    } else {
+      crossBankNegotiations.value = []
+      // Don't clobber a local error; surface a softer note only if local loaded.
+      if (!error.value) {
+        error.value = 'Lokalni pregovori učitani; cross-bank pregovore nije moguće učitati.'
+      }
+    }
   } finally {
     loading.value = false
   }
@@ -130,23 +261,37 @@ function resetFilters() {
   fetchNegotiations()
 }
 
-async function toggleHistory(offer: OtcOffer) {
-  if (expandedOfferId.value === offer.id) {
-    expandedOfferId.value = null
+async function toggleHistory(row: UnifiedRow) {
+  if (expandedKey.value === row.key) {
+    expandedKey.value = null
     return
   }
-  expandedOfferId.value = offer.id
+  expandedKey.value = row.key
   historyEntries.value = []
   historyError.value = ''
+
+  // Cross-bank negotiations have no per-step timeline endpoint; the expand
+  // row renders a static summary instead (see template).
+  if (row.source !== 'local' || !row.offer) {
+    return
+  }
+
   historyLoading.value = true
   try {
-    const res = await otcApi.getNegotiationHistory(offer.id)
+    const res = await otcApi.getNegotiationHistory(row.offer.id)
     historyEntries.value = res.data.entries || []
   } catch {
     historyError.value = 'Nije moguće učitati detalje pregovora.'
   } finally {
     historyLoading.value = false
   }
+}
+
+function crossBankLastModifiedByRole(neg: InterbankNegotiation) {
+  const byBuyer =
+    neg.lastModifiedBy.routingNumber === neg.buyerId.routingNumber &&
+    neg.lastModifiedBy.id === neg.buyerId.id
+  return byBuyer ? 'Kupac' : 'Prodavac'
 }
 
 onMounted(fetchNegotiations)
@@ -158,7 +303,7 @@ onMounted(fetchNegotiations)
       <div>
         <p class="eyebrow">OTC portal</p>
         <h1>Istorija pregovora</h1>
-        <p>Kompletna istorija OTC ponuda u kojima ste učestvovali, sa svakom kontraponudom (stare i nove vrednosti).</p>
+        <p>Kompletna istorija OTC ponuda u kojima ste učestvovali — lokalnih i cross-bank, sa svakom kontraponudom (stare i nove vrednosti).</p>
       </div>
       <div class="header-actions">
         <RouterLink to="/client/otc/offers" class="secondary-link">Aktivne ponude</RouterLink>
@@ -182,7 +327,7 @@ onMounted(fetchNegotiations)
         <input v-model="toFilter" type="date" />
       </label>
       <label>
-        Druga strana (ID)
+        Druga strana (ID / rutni broj)
         <input v-model="counterpartyFilter" type="number" min="1" placeholder="npr. 5" />
       </label>
       <div class="filter-actions">
@@ -195,19 +340,20 @@ onMounted(fetchNegotiations)
       <div class="panel-head">
         <div>
           <h2>Pregovori</h2>
-          <span class="panel-meta">Klikni na red da vidiš timeline kontraponuda.</span>
+          <span class="panel-meta">Klikni na red da vidiš timeline kontraponuda (lokalni) ili detalje (cross-bank).</span>
         </div>
-        <span class="panel-meta">{{ negotiations.length }} pregovora</span>
+        <span class="panel-meta">{{ rows.length }} pregovora</span>
       </div>
 
       <div v-if="loading" class="empty-state">Učitavam pregovore...</div>
       <div v-else-if="error" class="error-box">{{ error }}</div>
-      <div v-else-if="negotiations.length === 0" class="empty-state">Nema pregovora za izabrani filter.</div>
+      <div v-else-if="rows.length === 0" class="empty-state">Nema pregovora za izabrani filter.</div>
       <div v-else class="table-wrap">
         <table class="otc-table">
           <thead>
             <tr>
               <th>ID</th>
+              <th>Tip</th>
               <th>Uloga</th>
               <th>Druga strana</th>
               <th>Ticker</th>
@@ -221,51 +367,67 @@ onMounted(fetchNegotiations)
             </tr>
           </thead>
           <tbody>
-            <template v-for="offer in negotiations" :key="offer.id">
-              <tr class="clickable" @click="toggleHistory(offer)">
-                <td class="offer-id">#{{ offer.id }}</td>
-                <td>{{ role(offer) }}</td>
-                <td>{{ counterparty(offer) }}</td>
+            <template v-for="row in rows" :key="row.key">
+              <tr class="clickable" @click="toggleHistory(row)">
+                <td class="offer-id">{{ row.displayId }}</td>
                 <td>
-                  <div class="ticker">{{ offer.ticker }}</div>
-                  <div class="asset-meta">{{ offer.exchange.currency }}</div>
+                  <span class="source-pill" :class="row.source">
+                    {{ row.source === 'crossbank' ? 'Cross-bank' : 'Lokalni' }}
+                  </span>
                 </td>
-                <td>{{ fmtQuantity(offer.amount) }}</td>
-                <td>{{ fmtMoney(offer.pricePerStock) }}</td>
-                <td>{{ fmtMoney(offer.premium) }}</td>
-                <td>{{ fmtDate(offer.settlementDate) }}</td>
-                <td><span class="status-pill" :class="offer.status">{{ statusLabel(offer.status) }}</span></td>
-                <td class="asset-meta">{{ fmtDateTime(offer.lastModified) }}</td>
-                <td class="expand-cell">{{ expandedOfferId === offer.id ? '▲' : '▼' }}</td>
+                <td>{{ row.role }}</td>
+                <td>{{ row.counterparty }}</td>
+                <td>
+                  <div class="ticker">{{ row.ticker }}</div>
+                  <div class="asset-meta">{{ row.currency }}</div>
+                </td>
+                <td>{{ fmtQuantity(row.amount) }}</td>
+                <td>{{ fmtMoney(row.pricePerStock) }}</td>
+                <td>{{ fmtMoney(row.premium) }}</td>
+                <td>{{ fmtDate(row.settlementDate) }}</td>
+                <td><span class="status-pill" :class="row.statusKey">{{ row.statusLabel }}</span></td>
+                <td class="asset-meta">{{ fmtDateTime(row.lastModified) }}</td>
+                <td class="expand-cell">{{ expandedKey === row.key ? '▲' : '▼' }}</td>
               </tr>
-              <tr v-if="expandedOfferId === offer.id" class="history-row">
-                <td colspan="11">
-                  <div v-if="historyLoading" class="empty-inline">Učitavam timeline...</div>
-                  <div v-else-if="historyError" class="error-box" style="margin:0">{{ historyError }}</div>
-                  <div v-else-if="historyEntries.length === 0" class="empty-inline">Nema zabeleženih koraka.</div>
-                  <ol v-else class="timeline">
-                    <li v-for="entry in historyEntries" :key="entry.id">
-                      <div class="timeline-head">
-                        <span class="timeline-action" :class="entry.action">{{ actionLabel(entry.action) }}</span>
-                        <span class="timeline-actor">#{{ entry.actorId }} / {{ entry.actorType }}</span>
-                        <span class="timeline-time">{{ fmtDateTime(entry.createdAt) }}</span>
-                      </div>
-                      <div class="timeline-terms">
-                        <span>Količina: <strong>{{ fmtQuantity(entry.amount) }}</strong>
-                          <em v-if="entry.prevAmount != null && entry.prevAmount !== entry.amount"> (bilo {{ fmtQuantity(entry.prevAmount) }})</em>
-                        </span>
-                        <span>Cena: <strong>{{ fmtMoney(entry.pricePerStock) }}</strong>
-                          <em v-if="entry.prevPricePerStock != null && entry.prevPricePerStock !== entry.pricePerStock"> (bilo {{ fmtMoney(entry.prevPricePerStock) }})</em>
-                        </span>
-                        <span>Premija: <strong>{{ fmtMoney(entry.premium) }}</strong>
-                          <em v-if="entry.prevPremium != null && entry.prevPremium !== entry.premium"> (bilo {{ fmtMoney(entry.prevPremium) }})</em>
-                        </span>
-                        <span>Settlement: <strong>{{ fmtDate(entry.settlementDate) }}</strong>
-                          <em v-if="entry.prevSettlementDate && entry.prevSettlementDate !== entry.settlementDate"> (bilo {{ fmtDate(entry.prevSettlementDate) }})</em>
-                        </span>
-                      </div>
-                    </li>
-                  </ol>
+              <tr v-if="expandedKey === row.key" class="history-row">
+                <td colspan="12">
+                  <!-- Cross-bank: no per-step timeline endpoint; show a summary. -->
+                  <div v-if="row.source === 'crossbank' && row.crossBank" class="cross-summary">
+                    <span>Pregovor: <strong>{{ row.displayId }}</strong></span>
+                    <span>Banka druge strane: <strong>{{ row.crossBank.counterpartyRoutingNumber }}</strong></span>
+                    <span>Poslednju izmenu napravio: <strong>{{ crossBankLastModifiedByRole(row.crossBank) }}</strong></span>
+                    <span>Kreirano: <strong>{{ fmtDateTime(row.crossBank.createdAt) }}</strong></span>
+                    <span class="cross-note">Detaljan timeline kontraponuda nije dostupan za cross-bank pregovore.</span>
+                  </div>
+                  <!-- Local: full counter-offer timeline. -->
+                  <template v-else>
+                    <div v-if="historyLoading" class="empty-inline">Učitavam timeline...</div>
+                    <div v-else-if="historyError" class="error-box" style="margin:0">{{ historyError }}</div>
+                    <div v-else-if="historyEntries.length === 0" class="empty-inline">Nema zabeleženih koraka.</div>
+                    <ol v-else class="timeline">
+                      <li v-for="entry in historyEntries" :key="entry.id">
+                        <div class="timeline-head">
+                          <span class="timeline-action" :class="entry.action">{{ actionLabel(entry.action) }}</span>
+                          <span class="timeline-actor">#{{ entry.actorId }} / {{ entry.actorType }}</span>
+                          <span class="timeline-time">{{ fmtDateTime(entry.createdAt) }}</span>
+                        </div>
+                        <div class="timeline-terms">
+                          <span>Količina: <strong>{{ fmtQuantity(entry.amount) }}</strong>
+                            <em v-if="entry.prevAmount != null && entry.prevAmount !== entry.amount"> (bilo {{ fmtQuantity(entry.prevAmount) }})</em>
+                          </span>
+                          <span>Cena: <strong>{{ fmtMoney(entry.pricePerStock) }}</strong>
+                            <em v-if="entry.prevPricePerStock != null && entry.prevPricePerStock !== entry.pricePerStock"> (bilo {{ fmtMoney(entry.prevPricePerStock) }})</em>
+                          </span>
+                          <span>Premija: <strong>{{ fmtMoney(entry.premium) }}</strong>
+                            <em v-if="entry.prevPremium != null && entry.prevPremium !== entry.premium"> (bilo {{ fmtMoney(entry.prevPremium) }})</em>
+                          </span>
+                          <span>Settlement: <strong>{{ fmtDate(entry.settlementDate) }}</strong>
+                            <em v-if="entry.prevSettlementDate && entry.prevSettlementDate !== entry.settlementDate"> (bilo {{ fmtDate(entry.prevSettlementDate) }})</em>
+                          </span>
+                        </div>
+                      </li>
+                    </ol>
+                  </template>
                 </td>
               </tr>
             </template>
@@ -464,6 +626,24 @@ onMounted(fetchNegotiations)
   color: #94a3b8;
 }
 
+.source-pill {
+  display: inline-flex;
+  border-radius: 999px;
+  padding: 4px 9px;
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.source-pill.local {
+  background: #e2e8f0;
+  color: #334155;
+}
+
+.source-pill.crossbank {
+  background: #e0e7ff;
+  color: #3730a3;
+}
+
 .status-pill {
   display: inline-flex;
   border-radius: 999px;
@@ -474,7 +654,8 @@ onMounted(fetchNegotiations)
   font-weight: 800;
 }
 
-.status-pill.pending {
+.status-pill.pending,
+.status-pill.ongoing {
   background: #fef3c7;
   color: #92400e;
 }
@@ -490,9 +671,29 @@ onMounted(fetchNegotiations)
   color: #991b1b;
 }
 
+.status-pill.closed {
+  background: #f1f5f9;
+  color: #475569;
+}
+
 .history-row td {
   background: #f8fafc;
   white-space: normal;
+}
+
+.cross-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  color: #475569;
+  font-size: 13px;
+  padding: 4px 0;
+}
+
+.cross-note {
+  width: 100%;
+  color: #94a3b8;
+  font-style: italic;
 }
 
 .timeline {

--- a/src/views/client/ClientPortfolioView.vue
+++ b/src/views/client/ClientPortfolioView.vue
@@ -5,7 +5,7 @@ import { useClientPortfolioStore } from '../../stores/portfolio'
 import { useClientAuthStore } from '../../stores/clientAuth'
 import { clientPortfolioApi, type Holding, type DividendPayout } from '../../api/portfolio'
 import { clientTaxApi, type TaxSummary } from '../../api/tax'
-import { clientOrderApi, type Order } from '../../api/order'
+import { clientOrderApi, type Order, type OrderType, type OrderStatus } from '../../api/order'
 import { clientAccountApi, type ClientAccountItem } from '../../api/clientAccount'
 import BuyOrderModal from '../../components/BuyOrderModal.vue'
 import type { ListingItem } from '../../api/market'
@@ -72,6 +72,53 @@ const sortedBuyOrders = computed(() =>
     (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
   ),
 )
+
+// Buy-history filters: by status, order type, and creation-date range.
+const buyFilterStatus = ref<'' | OrderStatus>('')
+const buyFilterType = ref<'' | OrderType>('')
+const buyFilterFrom = ref('')
+const buyFilterTo = ref('')
+
+const filteredBuyOrders = computed(() => {
+  const from = buyFilterFrom.value ? new Date(buyFilterFrom.value) : null
+  const to = buyFilterTo.value ? new Date(`${buyFilterTo.value}T23:59:59`) : null
+  return sortedBuyOrders.value.filter((o) => {
+    if (buyFilterStatus.value && o.status !== buyFilterStatus.value) return false
+    if (buyFilterType.value && o.orderType !== buyFilterType.value) return false
+    const created = new Date(o.createdAt)
+    if (from && created < from) return false
+    if (to && created > to) return false
+    return true
+  })
+})
+
+function resetBuyFilters() {
+  buyFilterStatus.value = ''
+  buyFilterType.value = ''
+  buyFilterFrom.value = ''
+  buyFilterTo.value = ''
+}
+
+function orderStatusLabel(s: string) {
+  const map: Record<string, string> = {
+    pending: 'Pending',
+    approved: 'Approved',
+    declined: 'Declined',
+    done: 'Done',
+    cancelled: 'Cancelled',
+  }
+  return map[s] || s
+}
+
+// The order record has no dedicated execution timestamp; lastModification is the
+// time it reached its terminal state, so we surface it as the execution date for
+// done/declined orders and dash otherwise.
+function executionDate(o: Order) {
+  if (o.status === 'done' || o.status === 'declined') {
+    return formatOrderDate(o.lastModification)
+  }
+  return '-'
+}
 
 const marginOrders = computed(() =>
   sortedBuyOrders.value.filter((o) => o.isMargin),
@@ -410,42 +457,74 @@ onMounted(() => {
             <h2>Istorija kupovina akcija</h2>
             <span class="panel-meta">Svi nalozi kupovine, najnoviji prvo.</span>
           </div>
-          <span class="panel-meta">{{ buyOrders.length }} naloga</span>
+          <span class="panel-meta">{{ filteredBuyOrders.length }} / {{ buyOrders.length }} naloga</span>
         </div>
+
+        <div class="buy-filters">
+          <label>
+            Status
+            <select v-model="buyFilterStatus">
+              <option value="">Svi</option>
+              <option value="pending">Pending</option>
+              <option value="approved">Approved</option>
+              <option value="declined">Declined</option>
+              <option value="done">Done</option>
+              <option value="cancelled">Cancelled</option>
+            </select>
+          </label>
+          <label>
+            Tip ordera
+            <select v-model="buyFilterType">
+              <option value="">Svi</option>
+              <option value="market">Market</option>
+              <option value="limit">Limit</option>
+              <option value="stop">Stop</option>
+              <option value="stop_limit">Stop-Limit</option>
+            </select>
+          </label>
+          <label>
+            Od
+            <input v-model="buyFilterFrom" type="date" />
+          </label>
+          <label>
+            Do
+            <input v-model="buyFilterTo" type="date" />
+          </label>
+          <button class="reset-filters-btn" @click="resetBuyFilters">Poništi</button>
+        </div>
+
         <div v-if="buyOrdersError" class="error-box" style="margin:0">{{ buyOrdersError }}</div>
         <div v-else-if="!buyOrders.length" class="empty-inline">Nema istorije kupovina.</div>
+        <div v-else-if="!filteredBuyOrders.length" class="empty-inline">Nema naloga za izabrane filtere.</div>
         <div v-else class="buy-history-wrap">
           <table class="portfolio-table buy-history-table">
             <thead>
               <tr>
-                <th>Datum</th>
-                <th>Akcija</th>
-                <th>Tip naloga</th>
-                <th>Količina</th>
-                <th>Stop</th>
-                <th>Limit</th>
-                <th>Margin</th>
-                <th>AON</th>
-                <th>After hours</th>
-                <th>Ukupno plaćeno</th>
-                <th>Stanje pre uplate</th>
-                <th>Stanje posle uplate</th>
+                <th>Tip ordera</th>
+                <th>Hartija</th>
+                <th>Količina i cena izvršenja</th>
+                <th>Status</th>
+                <th>Datum kreiranja i izvršenja</th>
+                <th>Plaćena provizija</th>
               </tr>
             </thead>
             <tbody>
-              <tr v-for="o in sortedBuyOrders" :key="o.id">
-                <td>{{ formatOrderDate(o.createdAt) }}</td>
-                <td class="ticker">{{ o.assetTicker }}</td>
+              <tr v-for="o in filteredBuyOrders" :key="o.id">
                 <td>{{ orderTypeLabel(o.orderType) }}</td>
-                <td>{{ formatQuantity(o.quantity) }}</td>
-                <td>{{ o.stopValue != null ? formatAmount(o.stopValue) : '-' }}</td>
-                <td>{{ o.limitValue != null ? formatAmount(o.limitValue) : '-' }}</td>
-                <td><span :class="['flag-badge', o.isMargin ? 'flag-on' : 'flag-off']">{{ o.isMargin ? 'Da' : 'Ne' }}</span></td>
-                <td><span :class="['flag-badge', o.isAON ? 'flag-on' : 'flag-off']">{{ o.isAON ? 'Da' : 'Ne' }}</span></td>
-                <td><span :class="['flag-badge', o.afterHours ? 'flag-on' : 'flag-off']">{{ o.afterHours ? 'Da' : 'Ne' }}</span></td>
-                <td>{{ o.totalPaid > 0 ? formatAmount(o.totalPaid) : '-' }}</td>
-                <td>{{ o.balanceBefore > 0 || o.balanceAfter > 0 ? formatAmount(o.balanceBefore) : '-' }}</td>
-                <td>{{ o.balanceBefore > 0 || o.balanceAfter > 0 ? formatAmount(o.balanceAfter) : '-' }}</td>
+                <td>
+                  <div class="ticker">{{ o.assetTicker }}</div>
+                  <div class="asset-meta">{{ o.assetName }}</div>
+                </td>
+                <td>
+                  <div>{{ formatQuantity(o.quantity) }} kom</div>
+                  <div class="asset-meta">@ {{ formatAmount(o.pricePerUnit) }}</div>
+                </td>
+                <td><span :class="['status-badge', `status-${o.status}`]">{{ orderStatusLabel(o.status) }}</span></td>
+                <td>
+                  <div>{{ formatOrderDate(o.createdAt) }}</div>
+                  <div class="asset-meta">Izvršeno: {{ executionDate(o) }}</div>
+                </td>
+                <td>{{ o.commission > 0 ? formatAmount(o.commission) : '-' }}</td>
               </tr>
             </tbody>
           </table>
@@ -844,6 +923,58 @@ onMounted(() => {
   background: #f8fafc;
   z-index: 1;
 }
+
+.buy-filters {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 14px;
+  margin-bottom: 16px;
+}
+
+.buy-filters label {
+  display: grid;
+  gap: 6px;
+  font-size: 12px;
+  font-weight: 700;
+  color: #334155;
+}
+
+.buy-filters select,
+.buy-filters input {
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  padding: 8px 10px;
+  color: #0f172a;
+  font: inherit;
+  min-width: 140px;
+}
+
+.reset-filters-btn {
+  padding: 9px 14px;
+  border: none;
+  border-radius: 8px;
+  background: #f1f5f9;
+  color: #475569;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.status-badge {
+  display: inline-block;
+  padding: 2px 10px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.status-pending { background: #fef3c7; color: #92400e; }
+.status-approved { background: #dbeafe; color: #1d4ed8; }
+.status-done { background: #dcfce7; color: #166534; }
+.status-declined,
+.status-cancelled { background: #fee2e2; color: #991b1b; }
 
 .flag-badge {
   display: inline-block;


### PR DESCRIPTION
…story table

- Show cross-bank negotiations alongside local ones in the OTC negotiation history view.
- Exclude fund (fondacija) accounts from the employee bank buy dropdown.
- EmployeeFundDetailView: supervisor-level "Pokreni dividende" action, admin-overridable dividend-policy toggle and buy-for-fund, and a per-participant "Isplate dividendi po učesniku" table.
- Restructure client portfolio purchase-history table (Tip ordera, Hartija, količina + cena izvršenja, Status, datum kreiranja/izvršenja, provizija) with status / type / date-range filters.